### PR TITLE
Remove `type-check` option from the example

### DIFF
--- a/tools/javascript/tslint.md
+++ b/tools/javascript/tslint.md
@@ -26,7 +26,6 @@ linter:
     exclude: 'node_modules/**'
     project: 'tsconfig.json'
     rules-dir 'your_custom_rule'
-    type-check: true
     glob: '**/*.ts{,x}'
 ```
 


### PR DESCRIPTION
`type-check` option is already deprecated.