### PR TITLE
Fix Resource of the policy for EC2 instance

### DIFF
--- a/on-premises/quick-start/setup.md
+++ b/on-premises/quick-start/setup.md
@@ -137,7 +137,10 @@ An application that runs on an instance uploads your source code to S3. Thus, yo
       "Sid": "Stmt151246256049",
       "Action": "s3:*",
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::your-bucket-name/*"
+      "Resource": [
+        "arn:aws:s3:::your-bucket-name",
+        "arn:aws:s3:::your-bucket-name/*"
+      ]
     }
   ]
 }


### PR DESCRIPTION
catpost requires permissions to the bucket resource which is specified with `S3_BUCKET_NAME` environment variable.