### PR TITLE
Fix enterprise docs path

### DIFF
--- a/docs/enterprise/quick-start/setup.md
+++ b/docs/enterprise/quick-start/setup.md
@@ -2,7 +2,10 @@
 id: setup
 title: Setup Guide
 sidebar_label: Setup Guide
+hide_title: true
 ---
+
+# Setup Guide
 
 We have provided a guide to test whether applications have been correctly set up.
 * [Testing Guide](../testing/guide)

--- a/docs/enterprise/quick-start/update.md
+++ b/docs/enterprise/quick-start/update.md
@@ -2,7 +2,10 @@
 id: update
 title: Update Guide
 sidebar_label: Update Guide
+hide_title: true
 ---
+
+# Update Guide
 
 This section explains how to do a regular update of Sider with docker-compose.
 

--- a/docs/enterprise/releases/changelog.md
+++ b/docs/enterprise/releases/changelog.md
@@ -2,7 +2,10 @@
 id: changelog
 title: Release Notes
 sidebar_label: Release Notes
+hide_title: true
 ---
+
+# Release Notes
 
 ## Latest Release Tags
 

--- a/docs/enterprise/resources.md
+++ b/docs/enterprise/resources.md
@@ -2,7 +2,10 @@
 id: resources
 title: Computer Resources
 sidebar_label: Computer Resources
+hide_title: true
 ---
+
+# Computer Resources
 
 The following is a table of the computer resources required to serve Sider based on the number of developers.
 

--- a/docs/enterprise/testing/guide.md
+++ b/docs/enterprise/testing/guide.md
@@ -2,7 +2,10 @@
 id: guide
 title: Testing Guide
 sidebar_label: Testing for Sider running
+hide_title: true
 ---
+
+# Testing Guide
 
 Sider has equipped tools to check connections with services needed to run.
 

--- a/website/_redirects
+++ b/website/_redirects
@@ -1,0 +1,9 @@
+# Tools
+/tools  /introduction#analysis-tools
+
+# Enterprise
+/on-premises  /enterprise/releases/changelog
+/on-premises/quick-start  /enterprise/quick-start/setup
+/on-premises/quickstart/* /enterprise/quick-start/:splat
+/on-premises/testing  /enterprise/testings/guide
+/on-premises/releases* /enterprise/releases/changelog:splat

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -20,6 +20,11 @@ a:hover {
   text-decoration: underline;
 }
 
+/* To fix h1 position */
+header.postHeader:empty + article h1 {
+  margin-top: 0;
+}
+
 .button {
   border-color: var(--orange);
   color: var(--orange);


### PR DESCRIPTION
After changing document platform, `/on-premises` contents were broken. Hence, I fix this to set redirect.
See https://www.netlify.com/docs/redirects 

If this redirect were failed, I'd try that redirection with our Rack application.