### PR TITLE
Fix titles to allow users to show them on GitHub

### DIFF
--- a/docs/advanced-settings/inline-comments.md
+++ b/docs/advanced-settings/inline-comments.md
@@ -2,7 +2,10 @@
 id: inline-comments
 title: Inline Comments
 sidebar_label: Inline Comments
+hide_title: true
 ---
+
+# Inline Comments
 
 Sider provides an option to notify analysis results to GitHub as inline comments of pull requests. This option post comments to each pull request when analyzers detect problems. It will allow you to see the analysis results without leaving your pull request pages.
 
@@ -16,6 +19,4 @@ If an analysis tool finds more than 5 issues, a summary of the issues will be po
 
 ![Inline Comments Settings](../assets/inline-comments-setting.png)
 
-{% hint style="warning" %}
-If the Test Mode section is set to `ON`, Sider will post comments to your pull request. Note that this interface requires Sider to be enable as a GitHub App.
-{% endhint %}
+> If the Test Mode section is set to `ON`, Sider will post comments to your pull request. Note that this interface requires Sider to be enable as a GitHub App.

--- a/docs/advanced-settings/private-dependencies.md
+++ b/docs/advanced-settings/private-dependencies.md
@@ -2,11 +2,12 @@
 id: private-dependencies
 title: Private Dependencies
 sidebar_label: Private Dependencies
+hide_title: true
 ---
 
-Analyzing a private project sometimes needs access to another private repository. Your team might be using a Git repository to distribute a private library. This kind of dependency is supported in some tools including Bundler, npm.
+# Private Dependencies
 
-## Private Dependencies
+Analyzing a private project sometimes needs access to another private repository. Your team might be using a Git repository to distribute a private library. This kind of dependency is supported in some tools including Bundler, npm.
 
 We support using SSH to access a private repository during an analysis session.
 

--- a/docs/billing-and-plans.md
+++ b/docs/billing-and-plans.md
@@ -2,7 +2,10 @@
 id: billing-and-plans
 title: Billing and Plans
 sidebar_label: Billing and Plans
+hide_title: true
 ---
+
+# Billing and Plans
 
 ## Sider Plans
 

--- a/docs/enterprise/quick-start/setup.md
+++ b/docs/enterprise/quick-start/setup.md
@@ -10,8 +10,6 @@ hide_title: true
 We have provided a guide to test whether applications have been correctly set up.
 * [Testing Guide](../testing/guide.md)
 
-## Setup
-
 ### Creating an OAuth App for Sider
 First of all, create a new OAuth app on GitHub Enterprise; check "[Creating an OAuth App](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/)" as necessary.
 Fill in each field to match your specifications:
@@ -90,9 +88,7 @@ You must also create a new GitHub App for Sider. Follow these steps:
 ### Create a Database Instance
 Create a database instance on AWS; as needed, check "[Creating a DB Instance Running the MySQL Database Engine](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CreateInstance.html)". After creating a database, select the engine version `5.7.x`. Then select an instance type and a stage size according to your team's scale. We have confirmed behaviors when we set `db.t2.medium` and `50GB` storage size as a test.
 
-{% hint style="warning" %}
-Pay attention not to create initial databases when creating an instance on RDS because it has problems against character code. And, `max_allowed_packet` should be set around `128MB` to store analysis results in the database properly.
-{% end hint %}
+> Pay attention not to create initial databases when creating an instance on RDS because it has problems against character code. And, `max_allowed_packet` should be set around `128MB` to store analysis results in the database properly.
 
 ### Create an ElastiCache cluster
 Create an ElastiCache cluster; as needed, check "[What Is Amazon ElastiCache for Redis?](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/WhatIs.html)".

--- a/docs/getting-started/custom-configuration.md
+++ b/docs/getting-started/custom-configuration.md
@@ -2,7 +2,10 @@
 id: custom-configuration
 title: Custom Analysis Configuration
 sidebar_label: Custom Analysis Configuration
+hide_title: true
 ---
+
+# Custom Analysis Configuration
 
 You don't need to do any special configuration for Sider to start analyzing your code. However, Sider also offers advanced settings for special cases via the sideci.yml file.
 

--- a/docs/getting-started/permissions.md
+++ b/docs/getting-started/permissions.md
@@ -2,7 +2,10 @@
 id: permissions
 title: Permissions
 sidebar_label: Permissions
+hide_title: true
 ---
+
+# Permissions
 
 Users are required to have specific permissions to perform certain actions with Sider. Because Sider is integrated into GitHub, names of permission levels are the same as those set on GitHub.
 If you need more information about permission levels, read the GitHub documentations: "[Permission levels for an organization](https://help.github.com/articles/permission-levels-for-an-organization/)" and "[Repository permission levels for an organization](https://help.github.com/articles/repository-permission-levels-for-an-organization/)".

--- a/docs/getting-started/repository-settings.md
+++ b/docs/getting-started/repository-settings.md
@@ -2,7 +2,10 @@
 id: repository-settings
 title: Repository Settings
 sidebar_label: Repository Settings
+hide_title: true
 ---
+
+# Repository Settings
 
 The Repository Settings page allows you to configure Sider's behavior for each repository. You will see the Repository Settings screen upon adding your repository to Sider.
 

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -2,7 +2,10 @@
 id: setup
 title: Setting up Sider
 sidebar_label: Setting up Sider
+hide_title: true
 ---
+
+# Setting up Sider
 
 ## Sign Up
 

--- a/docs/getting-started/working-with-issues.md
+++ b/docs/getting-started/working-with-issues.md
@@ -2,7 +2,10 @@
 id: working-with-issues
 title: Working with Issues
 sidebar_label: Working with Issues
+hide_title: true
 ---
+
+# Working with Issues
 
 You can view all the issues Sider has found on a given pull request from the pull request page in Sider. This page also offers several handy ways to interact with issues, including ignoring issues and requesting feedback.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -2,7 +2,10 @@
 id: introduction
 title: Introduction
 sidebar_label: Introduction
+hide_title: true
 ---
+
+# Introduction
 
 ## About the documentation
 

--- a/docs/tools/css/scss-lint.md
+++ b/docs/tools/css/scss-lint.md
@@ -2,7 +2,10 @@
 id: scss-lint
 title: SCSS-Lint
 sidebar_label: SCSS-Lint
+hide_title: true
 ---
+
+# SCSS-Lint
 
 | Supported Version | Language | Web Site |
 | ----------------- | -------- | -------- |

--- a/docs/tools/css/stylelint.md
+++ b/docs/tools/css/stylelint.md
@@ -2,7 +2,10 @@
 id: stylelint
 title: stylelint
 sidebar_label: stylelint
+hide_title: true
 ---
+
+# stylelint
 
 | Language | Web Site |
 | -------- | -------- |

--- a/docs/tools/go/golint.md
+++ b/docs/tools/go/golint.md
@@ -2,7 +2,10 @@
 id: golint
 title: Golint
 sidebar_label: Golint
+hide_title: true
 ---
+
+# Golint
 
 | Supported Version | Language | Web Site |
 | ----------------- | -------- | -------- |

--- a/docs/tools/go/gometalinter.md
+++ b/docs/tools/go/gometalinter.md
@@ -2,7 +2,10 @@
 id: gometalinter
 title: Go Meta Linter
 sidebar_label: Go Meta Linter
+hide_title: true
 ---
+
+# Go Meta Linter
 
 | Supported Version | Language | Web Site |
 | ----------------- | -------- | -------- |

--- a/docs/tools/go/govet.md
+++ b/docs/tools/go/govet.md
@@ -2,7 +2,10 @@
 id: govet
 title: go vet
 sidebar_label: go vet
+hide_title: true
 ---
+
+# go vet
 
 | Supported Version | Language | Web Site |
 | ----------------- | -------- | -------- |

--- a/docs/tools/java/checkstyle.md
+++ b/docs/tools/java/checkstyle.md
@@ -2,7 +2,10 @@
 id: checkstyle
 title: Checkstyle
 sidebar_label: Checkstyle
+hide_title: true
 ---
+
+# Checkstyle
 
 | Supported Version | Language | Web Site |
 | ----------------- | -------- | -------- |

--- a/docs/tools/java/pmd.md
+++ b/docs/tools/java/pmd.md
@@ -2,7 +2,10 @@
 id: pmd
 title: PMD
 sidebar_label: PMD
+hide_title: true
 ---
+
+# PMD
 
 | Supported Version | Language | Web Site |
 | ----------------- | -------- | -------- |

--- a/docs/tools/javascript/coffeelint.md
+++ b/docs/tools/javascript/coffeelint.md
@@ -2,7 +2,10 @@
 id: coffeelint
 title: CoffeeLint
 sidebar_label: CoffeeLint
+hide_title: true
 ---
+
+# CoffeLint
 
 | Supported Version | Language | Web Site |
 | ----------------- | -------- | -------- |

--- a/docs/tools/javascript/eslint.md
+++ b/docs/tools/javascript/eslint.md
@@ -2,7 +2,10 @@
 id: eslint
 title: ESLint
 sidebar_label: ESLint
+hide_title: true
 ---
+
+# ESLint
 
 | Language | Web Site |
 | -------- | -------- |

--- a/docs/tools/javascript/jshint.md
+++ b/docs/tools/javascript/jshint.md
@@ -2,7 +2,10 @@
 id: jshint
 title: JSHint
 sidebar_label: JSHint
+hide_title: true
 ---
+
+# JSHint
 
 | Supported Version | Language | Web Site |
 | ----------------- | -------- | -------- |

--- a/docs/tools/javascript/tslint.md
+++ b/docs/tools/javascript/tslint.md
@@ -2,7 +2,10 @@
 id: tslint
 title: TSLint
 sidebar_label: TSLint
+hide_title: true
 ---
+
+# TSLint
 
 | Language | Web Site |
 | -------- | -------- |

--- a/docs/tools/others/goodcheck.md
+++ b/docs/tools/others/goodcheck.md
@@ -2,7 +2,10 @@
 id: goodcheck
 title: Goodcheck
 sidebar_label: Goodcheck
+hide_title: true
 ---
+
+# Goodcheck
 
 | Supported Version | Language | Web Site |
 | ----------------- | -------- | -------- |

--- a/docs/tools/others/misspell.md
+++ b/docs/tools/others/misspell.md
@@ -2,7 +2,10 @@
 id: misspell
 title: Misspell
 sidebar_label: Misspell
+hide_title: true
 ---
+
+# Misspell
 
 | Supported Version | Language | Web Site |
 | ----------------- | -------- | -------- |

--- a/docs/tools/php/codesniffer.md
+++ b/docs/tools/php/codesniffer.md
@@ -2,7 +2,10 @@
 id: codesniffer
 title: PHP_CodeSniffer
 sidebar_label: PHP_CodeSniffer
+hide_title: true
 ---
+
+# PHP_CodeSniffer
 
 | Supported Version | Language | Web Site |
 | ----------------- | -------- | -------- |

--- a/docs/tools/php/phinder.md
+++ b/docs/tools/php/phinder.md
@@ -2,7 +2,10 @@
 id: phinder
 title: Phinder
 sidebar_label: Phinder
+hide_title: true
 ---
+
+# Phinder
 
 | Supported Version | Language | Web Site |
 | ----------------- | -------- | -------- |

--- a/docs/tools/php/phpmd.md
+++ b/docs/tools/php/phpmd.md
@@ -2,7 +2,10 @@
 id: phpmd
 title: PHPMD
 sidebar_label: PHPMD
+hide_title: true
 ---
+
+# PHPMD
 
 | Supported Version | Language | Web Site |
 | ----------------- | -------- | -------- |

--- a/docs/tools/python/flake8.md
+++ b/docs/tools/python/flake8.md
@@ -2,7 +2,10 @@
 id: flake8
 title: Flake8
 sidebar_label: Flake8
+hide_title: true
 ---
+
+# Flake8
 
 | Supported Version | Language | Web Site |
 | ----------------- | -------- | -------- |

--- a/docs/tools/ruby/brakeman.md
+++ b/docs/tools/ruby/brakeman.md
@@ -2,7 +2,10 @@
 id: brakeman
 title: Brakeman
 sidebar_label: Brakeman
+hide_title: true
 ---
+
+# Brakeman
 
 | Supported Version | Language | Web Site |
 | ----------------- | -------- | -------- |

--- a/docs/tools/ruby/haml-lint.md
+++ b/docs/tools/ruby/haml-lint.md
@@ -2,7 +2,10 @@
 id: haml-lint
 title: HAML-Lint
 sidebar_label: HAML-Lint
+hide_title: true
 ---
+
+# HAML-Lint
 
 | Supported Version | Language | Web Site |
 | ----------------- | -------- | -------- |

--- a/docs/tools/ruby/querly.md
+++ b/docs/tools/ruby/querly.md
@@ -2,7 +2,10 @@
 id: querly
 title: Querly
 sidebar_label: Querly
+hide_title: true
 ---
+
+# Querly
 
 | Supported Version | Language | Web Site |
 | ----------------- | -------- | -------- |

--- a/docs/tools/ruby/rails-bestpractices.md
+++ b/docs/tools/ruby/rails-bestpractices.md
@@ -2,7 +2,10 @@
 id: rails-bestpractices
 title: Rails Best Practices
 sidebar_label: Rails Best Practices
+hide_title: true
 ---
+
+# Rails Best Practices
 
 | Supported Version | Language | Web Site |
 | ----------------- | -------- | -------- |
@@ -73,8 +76,7 @@ This option allows you to exclude files/directories from analysis. If you would 
 ```yaml:sideci.yml
 linter:
   rails_best_practices:
-    options:
-      exclude: app/controllers/foo/,app/models/bar.rb
+    exclude: app/controllers/foo/,app/models/bar.rb
 ```
 
 #### `only`
@@ -84,8 +86,7 @@ This option manages files/directories to analyze. When this option is present, S
 ```yaml:sideci.yml
 linter:
   rails_best_practices:
-    options:
-      only: app/controllers/,app/models/,lib/foo.rb
+    only: app/controllers/,app/models/,lib/foo.rb
 ```
 
 #### `config`

--- a/docs/tools/ruby/reek.md
+++ b/docs/tools/ruby/reek.md
@@ -2,7 +2,10 @@
 id: reek
 title: Reek
 sidebar_label: Reek
+hide_title: true
 ---
+
+# Reek
 
 | Supported Version | Language | Web Site |
 | ----------------- | -------- | -------- |

--- a/docs/tools/ruby/rubocop.md
+++ b/docs/tools/ruby/rubocop.md
@@ -2,7 +2,10 @@
 id: rubocop
 title: RuboCop
 sidebar_label: RuboCop
+hide_title: true
 ---
+
+# RuboCop
 
 | Language | Web Site |
 | -------- | -------- |

--- a/docs/tools/swift/swiftlint.md
+++ b/docs/tools/swift/swiftlint.md
@@ -2,7 +2,10 @@
 id: swiftlint
 title: SwiftLint
 sidebar_label: SwiftLint
+hide_title: true
 ---
+
+# SwiftLint
 
 | Supported Version | Language | Web Site |
 | ----------------- | -------- | -------- |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,7 +2,10 @@
 id: troubleshooting
 title: Troubleshooting
 sidebar_label: Troubleshooting
+hide_title: true
 ---
+
+# Troubleshooting
 
 ## I cannot find my organization
 This may be because Sider does not have access to your organization on GitHub. You can solve this problem by granting Sider access permission to your organization on GitHub shown as the following:

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -21,7 +21,7 @@ a:hover {
 }
 
 /* To fix h1 position */
-header.postHeader:empty + article h1 {
+article h1 {
   margin-top: 0;
 }
 


### PR DESCRIPTION
Use `hide_title` to enable h1 as `#` with markdown.
It will be trivial changes for users who see our docs on help.sider.review, but it will help for users who do it on GitHub.com.

See: https://github.com/sider/sider-docs/pull/98#discussion_r254556951