### PR TITLE
Add note about resque-scheduler

### DIFF
--- a/docs/enterprise/containers.md
+++ b/docs/enterprise/containers.md
@@ -81,7 +81,7 @@ $ docker run catpost:TAG bundle exec puma
 The `catpost_worker` runs with `rake` command. Use the following command to run `catpost_worker`.
 
 ```
-$ docker run catpost:TAG bundle exec rake resque:work
+$ docker run catpost:TAG bundle exec rake environment resque:work
 ```
 
 `catpost_worker` does not listen on any port.

--- a/docs/enterprise/containers.md
+++ b/docs/enterprise/containers.md
@@ -86,6 +86,19 @@ $ docker run catpost:TAG bundle exec rake environment resque:work
 
 `catpost_worker` does not listen on any port.
 
+### Running the job scheduler
+
+This scheduler container does not require much processor power.
+You need only one scheduler in the whole system of Sider Enterprise, but you can run multiple scheduler containers for redundancy.
+
+The `catpost_scheduler` runes with `rake` command. Use the following command to run `catpost_scheduler`.
+
+```
+$ docker run catpost:TAG bundle exec rake environment resque:scheduler
+```
+
+`catpost_scheduler` does not listen on any port.
+
 ### Running batch jobs
 
 `catpost` has daily batch jobs, which runs with `rake` command. Use the following command to run daily batch jobs.

--- a/docs/enterprise/outline.md
+++ b/docs/enterprise/outline.md
@@ -86,10 +86,10 @@ Note that:
 * `catpost` caches Git repositories in storage.
 * `setaria` requires access to a Docker service.
 
-You have to start six kinds of processes to run Sider.
+You have to start seven kinds of processes to run Sider.
 
 * `sideci_web` and `sideci_worker` using `sideci` image
-* `catpost_web` and `catpost_worker` using `catpost` image
+* `catpost_web`, `catpost_worker`, and `catpost_scheduler` using `catpost` image
 * `setaria_web` and `setaria_worker` using `setaria` image
 
 ### License and Authorization


### PR DESCRIPTION
We need to run [resque-scheduler](https://github.com/resque/resque-scheduler) for delayed retry of catpost jobs.