### PR TITLE
Follow up of close restrictions in working with issues

### DIFF
--- a/docs/getting-started/working-with-issues.md
+++ b/docs/getting-started/working-with-issues.md
@@ -45,9 +45,6 @@ Make sure to carefully review all of the changes and double-check the issues tha
 If you see an issue you do not think should be ignored, click the `Reopen` button and ask the developer to fix it.
 
 ## Who Can Close Issues?
-Sider decides whether to allow users to close issues based on their GitHub permissions. If a user does not have permission to push to the repository, Sider will not grant them permission to close issues.
+By default users with write or admin permissions can close issues.
 
-* If a user has permission to push to the repository, Sider will assume they are qualified and experienced enough developers to judge which issues can be ignored safely.
-* If developers are not allowed to push to the repository, Sider will assume they are junior developers and not allow them to close issues.
-
-We believe this gives your team a good balance of control and flexibility.
+You can also change this restriction to only users with admin permissions. See [Restricting access to Close button](../advanced-settings/restricting-access-to-close-button.md).


### PR DESCRIPTION
Follow up of https://blog.sideci.com/restricting-access-to-close-button-b0d3e0c12346