### PR TITLE
Add `gaTrackingId`

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -112,6 +112,8 @@ const siteConfig = {
   // wrapPagesHTML: true,
 
   editUrl: 'https://github.com/sider/sider-docs/edit/master/docs/',
+  
+  gaTrackingId: 'UA-48995135-1',
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
See https://docusaurus.io/docs/en/site-config#gatrackingid-string

![image](https://user-images.githubusercontent.com/473530/53791723-6af5f580-3f6d-11e9-840b-466f0c54bf85.png)
