### PR TITLE
Add # of analyses on resources.md

### DIFF
--- a/docs/enterprise/resources.md
+++ b/docs/enterprise/resources.md
@@ -9,7 +9,7 @@ hide_title: true
 
 The following is a table of the computer resources required to serve Sider based on the number of developers and analyses.
 
-| # of developers | # of Analyses | Memory |
+| # of developers | # of Analyses/day | Memory |
 |-----------------|---------------|--------|
 | 0 (for testing) | -             | 8GB    |
 | ~50             | ~100          | 32GB   |
@@ -18,7 +18,7 @@ The following is a table of the computer resources required to serve Sider based
 
 The number of analyses are based on the usage on our SaaS version.
 Sider starts analysis when new commits are pushed to the GitHub pull request.
-It is clear that the estimation is rough, and you should try with your own workload to make your estimation more acculate.
+It is clear that the estimation is rough, and you should try with your own workload to make your estimation more accurate.
 
 ## Estimating Required Resources
 
@@ -55,4 +55,3 @@ The following table is an example of how many containers you need based on the n
 | catpost-worker | 2 | 3 | 8 |
 | setaria-web | 1 | 2 | 2 |
 | setaria-worker | 10 | 20 | 50 |
-

--- a/docs/enterprise/resources.md
+++ b/docs/enterprise/resources.md
@@ -7,14 +7,18 @@ hide_title: true
 
 # Computer Resources
 
-The following is a table of the computer resources required to serve Sider based on the number of developers.
+The following is a table of the computer resources required to serve Sider based on the number of developers and analyses.
 
-| # of developers | Memory |
-|-----------------|--------|
-| 0 (for testing) | 8GB    |
-| ~50             | 32GB   |
-| ~250            | 64GB   |
-| ~1000           | 150GB  |
+| # of developers | # of Analyses | Memory |
+|-----------------|---------------|--------|
+| 0 (for testing) | -             | 8GB    |
+| ~50             | ~100          | 32GB   |
+| ~250            | ~500          | 64GB   |
+| ~1,000          | ~2,000        | 150GB  |
+
+The number of analyses are based on the usage on our SaaS version.
+Sider starts analysis when new commits are pushed to the GitHub pull request.
+It is clear that the estimation is rough, and you should try with your own workload to make your estimation more acculate.
 
 ## Estimating Required Resources
 


### PR DESCRIPTION
The capacity planning for Sider Enterprise clearly requires the number of analyses (commits), and this is it.

The # of analyses are based on the SaaS version. We know the number is insufficient to help your planning for Sider Enterprise, but we believe having this number is better than nothing.