### PR TITLE
Fix broken syntax highlight for `sideci.yml` code

### DIFF
--- a/docs/getting-started/custom-configuration.md
+++ b/docs/getting-started/custom-configuration.md
@@ -13,7 +13,7 @@ You don't need to do any special configuration for Sider to start analyzing your
 
 First, add a file named `sideci.yml` in your project's root directory.
 
-```yaml:sideci.yml
+```yaml
 linter:
   rubocop:
     config: 'lint_yml/.myrubocop.yml'
@@ -44,7 +44,7 @@ You can use `sideci.yml` to configure each analyzer's vendor-supplied settings. 
 
 This is a common option available to all analyzers. This option specifies a directory in your repository from which Sider should run the analyzer in. For example, if you have all your JavaScript files in the `./frontend` directory, you could configure `sideci.yml` like this:
 
-```yaml:sideci.yml
+```yaml
 linter:
   eslint:
     root_dir: 'frontend'
@@ -56,7 +56,7 @@ Sider will run ESLint analysis in `./frontend` directory.
 
 Some analyzers written in Ruby can be customized with third-party [gems](https://rubygems.org/). With Sider, you can use [Bundler](https://bundler.io/) to install any gem. The following is an example of installing RuboCop plugins or configuration gems:
 
-```yaml:sideci.yml
+```yaml
 linter:
   rubocop:
     gems:
@@ -66,7 +66,7 @@ linter:
 
 You can also set the version of the analyzer you want to use. However, the version must meet Sider's constraints. Please refer to each analyzer page.
 
-```yaml:sideci.yml
+```yaml
 linter:
   rubocop:
     gems:
@@ -88,7 +88,7 @@ However, if the version written in `Gemfile.lock` does not satisfy our constrain
 
 If you want to additionally install a specific gem written in `Gemfile.lock`, you can omit the `version` as follows:
 
-```yaml:sideci.yml
+```yaml
 linter:
   rubocop:
     gems:
@@ -101,7 +101,7 @@ If the gem is not found in `Gemfile.lock`, the latest version is installed.
 
 You can select an alternate RubyGems repository as a gem source via the source option:
 
-```yaml:sideci.yml
+```yaml
 linter:
   rubocop:
     gems:
@@ -114,7 +114,7 @@ linter:
 
 You can also install a gem in a git repository. Please note that the git option cannot be specified with version or source.
 
-```yaml:sideci.yml
+```yaml
 linter:
   rubocop:
     gems:
@@ -145,7 +145,7 @@ This option allows you to ignore specific files. It helps to improve the analysi
 
 In order to use this option, add it to `sideci.yml` like this:
 
-```yaml:sideci.yml
+```yaml
 linter:
   # Some linter settings...
 ignore:
@@ -161,7 +161,7 @@ When setting this option, Sider will not analyze the branch specified in this op
 
 In order to use this option, add it to `sideci.yml` like this:
 
-```yaml:sideci.yml
+```yaml
 linter:
   # Some linter settings...
 branches:
@@ -180,7 +180,7 @@ With the above setting, Sider will ignore `master`, `development` and `another_b
 
 You can also use regular expressions as the `exclude` pattern:
 
-```yaml:sideci.yml
+```yaml
 branches:
   exclude:
     - /^release-.*$/

--- a/docs/tools/css/scss-lint.md
+++ b/docs/tools/css/scss-lint.md
@@ -19,7 +19,7 @@ To start using SCSS-Lint, enable it in [Repository Settings](../../getting-start
 
 Here are example settings for SCSS-Lint:
 
-```yaml:sideci.yml
+```yaml
 linter:
   scss_lint:
     config: lint_yml/.scss-lint.yml

--- a/docs/tools/css/stylelint.md
+++ b/docs/tools/css/stylelint.md
@@ -31,7 +31,7 @@ If you don't have any custom configuration defined, Sider uses the latest versio
 
 Here are example settings for stylelint under `stylelint`:
 
-```yaml:sideci.yml
+```yaml
 linter:
   stylelint:
     npm_install: true

--- a/docs/tools/go/gometalinter.md
+++ b/docs/tools/go/gometalinter.md
@@ -41,7 +41,7 @@ If your `sideci.yml` does not contain `config` option, Sider will use the defaul
 
 Put your Go Meta Linter configuration under `gometalinter`:
 
-```yaml:sideci.yml
+```yaml
 linter:
   gometalinter:
     import_path: github.com/your-org-name/your-repo-name

--- a/docs/tools/java/checkstyle.md
+++ b/docs/tools/java/checkstyle.md
@@ -19,7 +19,7 @@ To start using Checkstyle, enable it in [Repository Settings](../../getting-star
 
 You can customize Checkstyle analysis using `sideci.yml`.
 
-```yaml:sideci.yml
+```yaml
 linter:
   checkstyle:
     config: google

--- a/docs/tools/java/pmd.md
+++ b/docs/tools/java/pmd.md
@@ -19,7 +19,7 @@ To start using PMD, enable it in [Repository Settings](../../getting-started/rep
 
 You can customize PMD analysis by using `sideci.yml`:
 
-```yaml:sideci.yml
+```yaml
 linter:
   pmd_java:
     dir: src

--- a/docs/tools/javascript/coffeelint.md
+++ b/docs/tools/javascript/coffeelint.md
@@ -19,7 +19,7 @@ To start using CoffeeLint, enable it in [Repository Settings](../../getting-star
 
 Here are example settings for CoffeeLint:
 
-```yaml:sideci.yml
+```yaml
 linter:
   coffeelint:
     npm_install: true

--- a/docs/tools/javascript/eslint.md
+++ b/docs/tools/javascript/eslint.md
@@ -21,7 +21,7 @@ $ npm install eslint -D
 
 Add `sideci.yml` to your repository:
 
-```yaml:sideci.yml
+```yaml
 linter:
   eslint:
     npm_install: true
@@ -39,7 +39,7 @@ Sider provides a recommended configuration for ESLint. The configuration is used
 
 Put settings for ESLint under `eslint`:
 
-```yaml:sideci.yml
+```yaml
 linter:
   eslint:
     npm_install: true
@@ -89,7 +89,7 @@ If your `package.json` contains a dependency which cannot be installed in the Si
 
 This option controls name of directory to pass to `eslint`. The default value is `.`. Declare directory to analyze like this:
 
-```yaml:sideci.yml
+```yaml
 linter:
   eslint:
     dir: frontend/src
@@ -97,7 +97,7 @@ linter:
 
 If you would like to analyze multiple directories with Sider, you can set them like this:
 
-```yaml:sideci.yml
+```yaml
 linter:
   eslint:
     dir:
@@ -110,7 +110,7 @@ linter:
 
 This option allows you specify an additional configuration file. ESLint uses your `.eslintrc{.yaml,.yml,.json}` in the root directory of your project by default, so you don't need to use this option if you have used one of the default filenames. If your ESLint config file has a different name, or is not in the root directory, you should use this option:
 
-```yaml:sideci.yml
+```yaml
 linter:
   eslint:
     options:

--- a/docs/tools/javascript/jshint.md
+++ b/docs/tools/javascript/jshint.md
@@ -25,7 +25,7 @@ Sider uses its default configuration where there is no custom configuration pres
 
 ## Configuration via `sideci.yml`
 
-```yaml:sideci.yml
+```yaml
 linter:
   jshint:
     dir: src

--- a/docs/tools/javascript/tslint.md
+++ b/docs/tools/javascript/tslint.md
@@ -25,7 +25,7 @@ If you need customization, use the standard TSLint config file. Create a `tslint
 
 Here is an example setting for TSLint under `tslint`:
 
-```yaml:sideci.yml
+```yaml
 linter:
   tslint:
     npm_install: true
@@ -76,7 +76,7 @@ This option controls which files TSLint excludes from linting. The default value
 
 If you want to exclude multiple files/directories, declare them as a sequence:
 
-```yaml:sideci.yml
+```yaml
 linter:
   tslint:
     exclude:
@@ -95,7 +95,7 @@ This option controls customized rules that TSLint inspects.
 
 If you want to set multiple custom rules, declare them as follow:
 
-```yaml:sideci.yml
+```yaml
 linter:
   tslint:
     rules-dir:

--- a/docs/tools/others/goodcheck.md
+++ b/docs/tools/others/goodcheck.md
@@ -26,7 +26,7 @@ Visit [its project page](https://github.com/sider/goodcheck#goodcheckyml) for mo
 
 Here are example settings for Goodcheck under `goodcheck`:
 
-```yaml:sideci.yml
+```yaml
 linter:
   goodcheck:
     config: lib/goodcheck.yml

--- a/docs/tools/others/misspell.md
+++ b/docs/tools/others/misspell.md
@@ -19,7 +19,7 @@ To start using Misspell, enable it in repository settings page on [sider.review]
 
 Here are example settings for Misspell under `misspell`:
 
-```yaml:sideci.yml
+```yaml
 linter:
   misspell:
     exclude:

--- a/docs/tools/php/codesniffer.md
+++ b/docs/tools/php/codesniffer.md
@@ -15,7 +15,7 @@ hide_title: true
 
 To start using PHP\_CodeSniffer, enable it in [Repository Settings](../../getting-started/repository-settings.md). To configure the coding standard you want to follow, add `sideci.yml` in your repository and set the `standard` option:
 
-```yaml:sideci.yml
+```yaml
 linter:
   code_sniffer:
     dir: app/
@@ -42,7 +42,7 @@ Autodetection is based on file names and directory structure. If autodetection f
 
 Example setting for PHP\_CodeSniffer under `code_sniffer`:
 
-```yaml:sideci.yml
+```yaml
 linter:
   code_sniffer:
     dir: app/

--- a/docs/tools/php/phinder.md
+++ b/docs/tools/php/phinder.md
@@ -26,7 +26,7 @@ To start using Phinder, enable it in [Repository Settings](../../getting-started
 
 Here's a sample Phinder configuration in `sideci.yml`:
 
-```yaml:sideci.yml
+```yaml
 linter:
   phinder:
     rule: myphinder.yml
@@ -45,7 +45,7 @@ linter:
 This option allows you to specify file or directory name where your Phinder ruleset is located.
 If you set file name, Phinder will use the file for analysis instead of `phinder.yml`. If this is a directory name, Phinder will analyze your project with all `yml` files under the directory.
 
-```yaml:sideci.yml
+```yaml
 linter:
   phinder:
     rule: rules # Phinder will use './rules/*.yml' when analyzing.
@@ -55,7 +55,7 @@ linter:
 
 This option allows you to specify the path of your project to analyze. If this is a file name, Phinder will analyze merely the file. If it's a directory, Phinder will analyze all `.php` files under the directory.
 
-```yaml:sideci.yml
+```yaml
 linter:
   phinder:
     php: src # Phinder will analyze '.php' files in '/src' directory.

--- a/docs/tools/php/phpmd.md
+++ b/docs/tools/php/phpmd.md
@@ -21,7 +21,7 @@ You can use `sideci.yml` to configure PHPMD.
 
 If you have your own `ruleset.xml` for your project, you can add it under the `rule` option in `sideci.yml`.
 
-```yaml:sideci.yml
+```yaml
 linter:
   phpmd:
     rule: ruleset.xml
@@ -35,7 +35,7 @@ To mitigate this, Sider deletes files that are not changed in the pull request. 
 
 If it still times out, you can limit the target of PHPMD analysis by using the `target` option:
 
-```yaml:sideci.yml
+```yaml
 linter:
   phpmd:
     target:
@@ -53,7 +53,7 @@ If you leave the `rule` option undefined in `sideci.yml`, Sider runs PHPMD with 
 
 Here is are some example settings for PHPMD in `sideci.yml`:
 
-```yaml:sideci.yml
+```yaml
 linter:
   phpmd:
     target:
@@ -98,7 +98,7 @@ The valid rule names are:
 
 You can also specify a rule set file name:
 
-```yaml:sideci.yml
+```yaml
 linter:
   phpmd:
     rule: ruleset.xml

--- a/docs/tools/python/flake8.md
+++ b/docs/tools/python/flake8.md
@@ -35,7 +35,7 @@ Our default configuration is available here:
 
 Here are example settings for Flake8 under `flake8`:
 
-```yaml:sideci.yml
+```yaml
 linter:
   flake8:
     version: 2

--- a/docs/tools/ruby/brakeman.md
+++ b/docs/tools/ruby/brakeman.md
@@ -15,7 +15,7 @@ hide_title: true
 
 Here are some example settings for Brakeman in `sideci.yml`, under `brakeman`:
 
-```yaml:sideci.yml
+```yaml
 linter:
   querly:
     gems:

--- a/docs/tools/ruby/haml-lint.md
+++ b/docs/tools/ruby/haml-lint.md
@@ -15,7 +15,7 @@ hide_title: true
 
 Example settings for HAML-Lint under `haml_lint`:
 
-```yaml:sideci.yml
+```yaml
 linter:
   haml_lint:
     gems:

--- a/docs/tools/ruby/querly.md
+++ b/docs/tools/ruby/querly.md
@@ -31,7 +31,7 @@ Visit the Querly project page for more information about writing rules:
 
 Here are some example settings for Querly in `sideci.yml`, under `querly`:
 
-```yaml:sideci.yml
+```yaml
 linter:
   querly:
     gems:

--- a/docs/tools/ruby/rails-bestpractices.md
+++ b/docs/tools/ruby/rails-bestpractices.md
@@ -15,7 +15,7 @@ hide_title: true
 
 Here are some example settings for Rails Best Practices in `sideci.yml`, under `rails_best_practices`:
 
-```yaml:sideci.yml
+```yaml
 linter:
   rails_best_practices:
     gems:
@@ -53,7 +53,7 @@ Rails Best Practices supports some template engines. Sider finds the following g
 
 These gems will not be installed when the `gems` option is specified. We encourage you to explicitly specify gems in the [`gems` option](../../getting-started/custom-configuration.md#gems-option) in `sideci.yml` as follows:
 
-```yaml:sideci.yml
+```yaml
 linter:
   rails_best_practices:
     gems:

--- a/docs/tools/ruby/reek.md
+++ b/docs/tools/ruby/reek.md
@@ -15,7 +15,7 @@ hide_title: true
 
 Here are some example settings for Reek in `sideci.yml`, under `reek`:
 
-```yaml:sideci.yml
+```yaml
 linter:
   reek:
     gems:

--- a/docs/tools/ruby/rubocop.md
+++ b/docs/tools/ruby/rubocop.md
@@ -15,7 +15,7 @@ hide_title: true
 
 Example settings for RuboCop under `rubocop`:
 
-```yaml:sideci.yml
+```yaml
 linter:
   rubocop:
     gems:
@@ -41,7 +41,7 @@ This option controls whether to run Rails Cops. If it is omitted, Sider automati
 
 This option is used for the case that you do not wish Sider to run Rails Cops even though your project is a Ruby on Rails project.
 
-```yaml:sideci.yml
+```yaml
 linter:
   rubocop:
     rails: false

--- a/docs/tools/swift/swiftlint.md
+++ b/docs/tools/swift/swiftlint.md
@@ -21,7 +21,7 @@ To customize SwiftLint, put a `.swiftlint.yml` file in your repository.
 
 Here are example settings for SwiftLint under `swiftlint`:
 
-```yaml:sideci.yml
+```yaml
 linter:
   swiftlint:
     ignore_warnings: true


### PR DESCRIPTION
## Before

![image](https://user-images.githubusercontent.com/473530/55307161-a367f100-5491-11e9-93b7-ab52d0169da0.png)

https://help.sider.review/getting-started/custom-configuration#configuration-via-sideciyml

![image](https://user-images.githubusercontent.com/473530/55307210-ceeadb80-5491-11e9-8a8b-ab71dccceb7c.png)

https://help.sider.review/getting-started/custom-configuration#branches-option

## After

![image](https://user-images.githubusercontent.com/473530/55307181-b5499400-5491-11e9-9d5d-fb28cf5348a2.png)

https://deploy-preview-145--sider-docs.netlify.com/getting-started/custom-configuration#configuration-via-sideciyml

![image](https://user-images.githubusercontent.com/473530/55307227-dc07ca80-5491-11e9-8c58-a3ee9add58b8.png)

https://deploy-preview-145--sider-docs.netlify.com/getting-started/custom-configuration#branches-option

## Notes

Highlight.js doesn't support a class name with a filename... 😓 

![image](https://user-images.githubusercontent.com/473530/55307128-82070500-5491-11e9-9cfc-2df84cf7a205.png)
