### PR TITLE
Add invitation member required permission

### DIFF
--- a/docs/getting-started/permissions.md
+++ b/docs/getting-started/permissions.md
@@ -26,6 +26,8 @@ For the organization settings, Sider checks for permissions in an organization. 
 | Upgrade plan | | | X |
 | Cancel plan | | | X |
 | Assign seats | | | X |
+| Sync with GitHub | | | X |
+| Invite members | | | X |
 | Add Billing Manager | | | X |
 | Edit Billing Manager | | | X |
 | Delete Billing Manager | | | X |


### PR DESCRIPTION
We added a feature that organization owners can invite their members to Sider. Thus I add the required permission to use the feature.