### PR TITLE
Introduce inspectlet

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -7,6 +7,11 @@
 
 const React = require('react');
 
+// TODO: It is the workaround because Docusaurus 1.x does not support to edit <head> tag.
+//       Thus, if we update Docusaurus 2.x, delete this script and we would like to use Google Tag Manager,
+//       which is required set script tags within <head> and <body> tag.
+const Inspectlet = require('./plugins/Inspectlet')
+
 class Footer extends React.Component {
   docUrl(doc, language) {
     const baseUrl = this.props.config.baseUrl;
@@ -26,6 +31,7 @@ class Footer extends React.Component {
   render() {
     return (
       <footer className="nav-footer" id="footer">
+        <Inspectlet />
         <section className="sitemap">
           <div>
             <a href={this.props.config.baseUrl} className="nav-home">

--- a/website/core/plugins/Inspectlet.js
+++ b/website/core/plugins/Inspectlet.js
@@ -1,0 +1,18 @@
+const React = require('react');
+
+const inlineScript = `
+  window.__insp = window.__insp || [];
+  __insp.push(['wid', 664419537]);
+  (function() {
+    function ldinsp(){if(typeof window.__inspld != "undefined") return; window.__inspld = 1; var insp = document.createElement('script'); insp.type = 'text/javascript'; insp.async = true; insp.id = "inspsync"; insp.src = ('https:' == document.location.protocol ? 'https' : 'http') + '://cdn.inspectlet.com/inspectlet.js'; var x = document.getElementsByTagName('script')[0]; x.parentNode.insertBefore(insp, x); };
+    setTimeout(ldinsp, 500); document.readyState != "complete" ? (window.attachEvent ? window.attachEvent('onload', ldinsp) : window.addEventListener('load', ldinsp, false)) : ldinsp();
+  })();
+`
+
+class Inspectlet extends React.Component {
+  render() {
+    return <script type="text/javascript" id="inspectletjs" dangerouslySetInnerHTML={{__html: inlineScript}} />
+  }
+}
+
+module.exports = Inspectlet;

--- a/website/package.json
+++ b/website/package.json
@@ -9,6 +9,6 @@
     "rename-version": "docusaurus-rename-version"
   },
   "devDependencies": {
-    "docusaurus": "^1.8.0"
+    "docusaurus": "^1.10.0"
   }
 }

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -112,7 +112,7 @@ const siteConfig = {
   // wrapPagesHTML: true,
 
   editUrl: 'https://github.com/sider/sider-docs/edit/master/docs/',
-  
+
   gaTrackingId: 'UA-48995135-1',
 };
 

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1841,11 +1841,6 @@ deep-is@0.1.2:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.2.tgz#9ced65ea0bc0b09f42a6d79c1b1903f9d913cc18"
   integrity sha1-nO1l6gvAsJ9CptecGxkD+dkTzBg=
 
-deepmerge@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
-  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
-
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
@@ -1921,10 +1916,10 @@ dir-glob@2.0.0:
     arrify "^1.0.1"
     path-type "^3.0.0"
 
-docusaurus@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/docusaurus/-/docusaurus-1.8.0.tgz#d82eeb426c1f0fb69411f141fa9311213254ad1a"
-  integrity sha512-Hn+/simu3yiX+5ucqNvX6yTyXtH3BFu2UIeGiXcKiRG8Khos206SsQQ2B7DrBzeJ0duhPxi/I7zYMFyaF23UUQ==
+docusaurus@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/docusaurus/-/docusaurus-1.10.0.tgz#f32f8a3a7f2c3da38e48ccbc7a0fb148311e413d"
+  integrity sha512-59MHcOu+GCLAzjml9E5UYRVsQDqEheilTRuyYPzpMIo1mb8rJLy3ulsF8HfWPYOjo3Luc8OHqCoGVarFO0VEAg==
   dependencies:
     "@babel/core" "^7.0.0"
     "@babel/plugin-proposal-class-properties" "^7.0.0"
@@ -1944,7 +1939,6 @@ docusaurus@^1.8.0:
     cross-spawn "^6.0.5"
     crowdin-cli "^0.3.0"
     cssnano "^3.10.0"
-    deepmerge "^2.1.1"
     escape-string-regexp "^1.0.5"
     express "^4.15.3"
     feed "^1.1.0"
@@ -1968,7 +1962,7 @@ docusaurus@^1.8.0:
     react-dom "^16.5.0"
     remarkable "^1.7.1"
     request "^2.87.0"
-    shelljs "^0.7.8"
+    shelljs "^0.8.3"
     sitemap "^1.13.0"
     tcp-port-used "^0.1.2"
     tiny-lr "^1.1.1"
@@ -5218,10 +5212,10 @@ shell-quote@1.6.1:
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
 
-shelljs@^0.7.8:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
-  integrity sha1-3svPh0sNHl+3LhSxZKloMEjprLM=
+shelljs@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
+  integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"


### PR DESCRIPTION
Introduce Inspectlet but it's workaround.

Inspectlet documents said:

> The script provided by Inspectlet (look above for an example) should be placed anywhere in your site's HTML (preferrably in the <HEAD> section).

Because Docusaurus 1.x(and its latest version, 2.0.0-alpha16, is too) doesn't seem to allow users to edit `<head>` tag, I added Inspectlet tag to under `<footer>` tag, which is the only tag to editable today.

If Docusaurus 2.x relax edit limitation to users, I would like to introduce Google Tag Manager and move GA and Instpectlet to GTM.