### PR TITLE
Sider now recognizes `sider.yml`

### DIFF
--- a/docs/getting-started/custom-configuration.md
+++ b/docs/getting-started/custom-configuration.md
@@ -7,7 +7,7 @@ hide_title: true
 
 # Custom Analysis Configuration
 
-You don't need to do any special configuration for Sider to start analyzing your code. However, Sider also offers advanced settings for special cases via the sider.yml file.
+You don't need to do any special configuration for Sider to start analyzing your code. However, Sider also offers advanced settings for special cases via the `sider.yml` file.
 
 ## Configuration via `sider.yml`
 

--- a/docs/getting-started/custom-configuration.md
+++ b/docs/getting-started/custom-configuration.md
@@ -7,11 +7,11 @@ hide_title: true
 
 # Custom Analysis Configuration
 
-You don't need to do any special configuration for Sider to start analyzing your code. However, Sider also offers advanced settings for special cases via the sideci.yml file.
+You don't need to do any special configuration for Sider to start analyzing your code. However, Sider also offers advanced settings for special cases via the sider.yml file.
 
-## Configuration via `sideci.yml`
+## Configuration via `sider.yml`
 
-First, add a file named `sideci.yml` in your project's root directory.
+First, add a file named `sider.yml` in your project's root directory.
 
 ```yaml
 linter:
@@ -29,7 +29,7 @@ linter:
     glob: '**/*.{css,scss}'
 ```
 
-The options you can specify in `sideci.yml` are grouped into two categories:
+The options you can specify in `sider.yml` are grouped into two categories:
 
 1. Analyzer specific options
 2. Common options available to all analyzers
@@ -38,11 +38,11 @@ Currently, `root_dir` is the only common option.
 
 ## Analysis tool specific configuration
 
-You can use `sideci.yml` to configure each analyzer's vendor-supplied settings. Sider also provides extra options for some analyzers that configure how Sider runs the analyzer (for example, some tools might need to run `npm install` before beginning analysis). The tools documentation has more information about which options are available for each tool.
+You can use `sider.yml` to configure each analyzer's vendor-supplied settings. Sider also provides extra options for some analyzers that configure how Sider runs the analyzer (for example, some tools might need to run `npm install` before beginning analysis). The tools documentation has more information about which options are available for each tool.
 
 ## `root_dir` option
 
-This is a common option available to all analyzers. This option specifies a directory in your repository from which Sider should run the analyzer in. For example, if you have all your JavaScript files in the `./frontend` directory, you could configure `sideci.yml` like this:
+This is a common option available to all analyzers. This option specifies a directory in your repository from which Sider should run the analyzer in. For example, if you have all your JavaScript files in the `./frontend` directory, you could configure `sider.yml` like this:
 
 ```yaml
 linter:
@@ -78,7 +78,7 @@ linter:
 
 Sider decides the analyzer version in the following order:
 
-1. `gems` option in `sideci.yml`
+1. `gems` option in `sider.yml`
 2. `Gemfile.lock`
 3. The default version
 
@@ -143,7 +143,7 @@ If you would like to install a gem located in a private git repository, see [pri
 
 This option allows you to ignore specific files. It helps to improve the analysis execution time and the analysis stability.
 
-In order to use this option, add it to `sideci.yml` like this:
+In order to use this option, add it to `sider.yml` like this:
 
 ```yaml
 linter:
@@ -159,7 +159,7 @@ ignore:
 This option allows you to exclude branches from the analysis. If there are branches that are unnecessary for your team to analyze, use the `branches` option.
 When setting this option, Sider will not analyze the branch specified in this option.
 
-In order to use this option, add it to `sideci.yml` like this:
+In order to use this option, add it to `sider.yml` like this:
 
 ```yaml
 linter:

--- a/docs/tools/css/scss-lint.md
+++ b/docs/tools/css/scss-lint.md
@@ -15,7 +15,7 @@ hide_title: true
 
 To start using SCSS-Lint, enable it in [Repository Settings](../../getting-started/repository-settings.md).
 
-## Configuration via `sideci.yml`
+## Configuration via `sider.yml`
 
 Here are example settings for SCSS-Lint:
 

--- a/docs/tools/css/stylelint.md
+++ b/docs/tools/css/stylelint.md
@@ -27,7 +27,7 @@ If you need more customization, use the standard stylelint config files. For exa
 
 If you don't have any custom configuration defined, Sider uses the latest version of [stylelit-config-recommended](https://github.com/stylelint/stylelint-config-recommended).
 
-## Configuration via `sideci.yml`
+## Configuration via `sider.yml`
 
 Here are example settings for stylelint under `stylelint`:
 

--- a/docs/tools/go/gometalinter.md
+++ b/docs/tools/go/gometalinter.md
@@ -17,7 +17,7 @@ hide_title: true
 
 To start using Go Meta Linter, enable it in repository setting.
 
-To customize Go Meta Linter, write your configuration, put it in your repository, and set up `sideci.yml`.
+To customize Go Meta Linter, write your configuration, put it in your repository, and set up `sider.yml`.
 
 ## Dependencies
 
@@ -28,16 +28,16 @@ If `glide.yaml` contains a dependency to a library in a private repository, plea
 * [Use other private repositories for analysis](../../advanced-settings/private-dependencies.md)
 
 
-> Note that need to set `import_path` option in `sideci.yml` when you would like to run `glide install` on analysis.
+> Note that need to set `import_path` option in `sider.yml` when you would like to run `glide install` on analysis.
 > See [here](#import_path) for details.
 
 ## Default Configuration
 
-If your `sideci.yml` does not contain `config` option, Sider will use the default configuration. The default configuration is available in our repository.
+If your `sider.yml` does not contain `config` option, Sider will use the default configuration. The default configuration is available in our repository.
 
 * [Sider's configuration for Go Meta Linter](https://github.com/actcat/sideci_config/blob/master/go/gometalinter/gometalinter.json)
 
-## Configuration via `sideci.yml`
+## Configuration via `sider.yml`
 
 Put your Go Meta Linter configuration under `gometalinter`:
 

--- a/docs/tools/java/checkstyle.md
+++ b/docs/tools/java/checkstyle.md
@@ -17,7 +17,7 @@ To start using Checkstyle, enable it in [Repository Settings](../../getting-star
 
 ## Configuration
 
-You can customize Checkstyle analysis using `sideci.yml`.
+You can customize Checkstyle analysis using `sider.yml`.
 
 ```yaml
 linter:

--- a/docs/tools/java/pmd.md
+++ b/docs/tools/java/pmd.md
@@ -17,7 +17,7 @@ To start using PMD, enable it in [Repository Settings](../../getting-started/rep
 
 ## Configuration
 
-You can customize PMD analysis by using `sideci.yml`:
+You can customize PMD analysis by using `sider.yml`:
 
 ```yaml
 linter:

--- a/docs/tools/javascript/coffeelint.md
+++ b/docs/tools/javascript/coffeelint.md
@@ -15,7 +15,7 @@ hide_title: true
 
 To start using CoffeeLint, enable it in [Repository Settings](../../getting-started/repository-settings.md).
 
-## Configuration via `sideci.yml`
+## Configuration via `sider.yml`
 
 Here are example settings for CoffeeLint:
 

--- a/docs/tools/javascript/eslint.md
+++ b/docs/tools/javascript/eslint.md
@@ -19,7 +19,7 @@ To start using ESLint in Sider, declare it as a dependency in your `package.json
 $ npm install eslint -D
 ```
 
-Add `sideci.yml` to your repository:
+Add `sider.yml` to your repository:
 
 ```yaml
 linter:
@@ -31,11 +31,11 @@ If you need more customization, use standard ESLint config files. For instance, 
 
 ## Default Configuration
 
-Sider provides a recommended configuration for ESLint. The configuration is used when you haven't added any ESLint configurations in your `sideci.yml` and don't have the default config files, `.eslintrc`, `.eslintrc.yml`, `.eslintrc.yaml`, or `.eslintrc.json` in your repository.
+Sider provides a recommended configuration for ESLint. The configuration is used when you haven't added any ESLint configurations in your `sider.yml` and don't have the default config files, `.eslintrc`, `.eslintrc.yml`, `.eslintrc.yaml`, or `.eslintrc.json` in your repository.
 
 * [Sider recommended settings for ESLint](https://github.com/actcat/sideci_config/blob/master/javascript/eslint/eslintrc)
 
-## Configuration via `sideci.yml`
+## Configuration via `sider.yml`
 
 Put settings for ESLint under `eslint`:
 

--- a/docs/tools/javascript/jshint.md
+++ b/docs/tools/javascript/jshint.md
@@ -23,7 +23,7 @@ Sider uses its default configuration where there is no custom configuration pres
 
 * [Sider's configuration for jshintrc](https://github.com/actcat/sideci_config/blob/master/javascript/jshint/sideci_jshintrc)
 
-## Configuration via `sideci.yml`
+## Configuration via `sider.yml`
 
 ```yaml
 linter:

--- a/docs/tools/javascript/tslint.md
+++ b/docs/tools/javascript/tslint.md
@@ -21,7 +21,7 @@ $ npm install tslint -D
 
 If you need customization, use the standard TSLint config file. Create a `tslint.json` file in the root directory of your repository.
 
-## Configuration via `sideci.yml`
+## Configuration via `sider.yml`
 
 Here is an example setting for TSLint under `tslint`:
 

--- a/docs/tools/others/goodcheck.md
+++ b/docs/tools/others/goodcheck.md
@@ -21,7 +21,7 @@ Visit [its project page](https://github.com/sider/goodcheck#goodcheckyml) for mo
  <iframe class="Video__iframe" src="https://www.youtube.com/embed/8Zpm2gguE1M" frameborder="0" allowfullscreen></iframe>
 </div>
 
-## Configuration via `sideci.yml`
+## Configuration via `sider.yml`
 
 Here are example settings for Goodcheck under `goodcheck`:
 

--- a/docs/tools/others/misspell.md
+++ b/docs/tools/others/misspell.md
@@ -15,7 +15,7 @@ hide_title: true
 
 To start using Misspell, enable it in repository settings page on [sider.review](https://sider.review/).
 
-## Configuration via `sideci.yml`
+## Configuration via `sider.yml`
 
 Here are example settings for Misspell under `misspell`:
 

--- a/docs/tools/php/codesniffer.md
+++ b/docs/tools/php/codesniffer.md
@@ -13,7 +13,7 @@ hide_title: true
 
 ## Getting Started
 
-To start using PHP\_CodeSniffer, enable it in [Repository Settings](../../getting-started/repository-settings.md). To configure the coding standard you want to follow, add `sideci.yml` in your repository and set the `standard` option:
+To start using PHP\_CodeSniffer, enable it in [Repository Settings](../../getting-started/repository-settings.md). To configure the coding standard you want to follow, add `sider.yml` in your repository and set the `standard` option:
 
 ```yaml
 linter:
@@ -36,9 +36,9 @@ The following standards are detected automatically:
 * `CakePHP`
 * `Symfony`
 
-Autodetection is based on file names and directory structure. If autodetection fails, you can specify a standard in `sideci.yml`.
+Autodetection is based on file names and directory structure. If autodetection fails, you can specify a standard in `sider.yml`.
 
-## Configuration via `sideci.yml`
+## Configuration via `sider.yml`
 
 Example setting for PHP\_CodeSniffer under `code_sniffer`:
 

--- a/docs/tools/php/phinder.md
+++ b/docs/tools/php/phinder.md
@@ -23,7 +23,7 @@ To start using Phinder, enable it in [Repository Settings](../../getting-started
 
 ## Sample Configuration
 
-Here's a sample Phinder configuration in `sideci.yml`:
+Here's a sample Phinder configuration in `sider.yml`:
 
 ```yaml
 linter:

--- a/docs/tools/php/phpmd.md
+++ b/docs/tools/php/phpmd.md
@@ -15,11 +15,11 @@ hide_title: true
 
 To start using PHPMD, enable it in [Repository Settings](../../getting-started/repository-settings.md).
 
-You can use `sideci.yml` to configure PHPMD.
+You can use `sider.yml` to configure PHPMD.
 
 ## Using Your Configuration File
 
-If you have your own `ruleset.xml` for your project, you can add it under the `rule` option in `sideci.yml`.
+If you have your own `ruleset.xml` for your project, you can add it under the `rule` option in `sider.yml`.
 
 ```yaml
 linter:
@@ -45,13 +45,13 @@ linter:
 
 ## Default Configuration
 
-If you leave the `rule` option undefined in `sideci.yml`, Sider runs PHPMD with our recommended settings. The recommended settings are available in our GitHub repository:
+If you leave the `rule` option undefined in `sider.yml`, Sider runs PHPMD with our recommended settings. The recommended settings are available in our GitHub repository:
 
 * [Sider recommended settings for PHPMD](https://github.com/actcat/sideci_config/blob/master/php/phpmd/sideci_config.xml)
 
-## Configuration via `sideci.yml`
+## Configuration via `sider.yml`
 
-Here is are some example settings for PHPMD in `sideci.yml`:
+Here is are some example settings for PHPMD in `sider.yml`:
 
 ```yaml
 linter:

--- a/docs/tools/python/flake8.md
+++ b/docs/tools/python/flake8.md
@@ -19,7 +19,7 @@ To customize Flake8, put a `.flake8` file in your repository.
 
 ## Python Version
 
-If your repository contains a `.python-version` file, the Python version is Sider will use the version specified in that file. You can also specify a Python version via `sideci.yml`. The default is Python 3.
+If your repository contains a `.python-version` file, the Python version is Sider will use the version specified in that file. You can also specify a Python version via `sider.yml`. The default is Python 3.
 
 The latest versions of Python 2 or Python 3 can be used.
 
@@ -31,7 +31,7 @@ Our default configuration is available here:
 
 * [Sider's configuration for Flake8](https://github.com/actcat/sideci_config/blob/master/python/flake8/sideci_config.ini)
 
-## Configuration via `sideci.yml`
+## Configuration via `sider.yml`
 
 Here are example settings for Flake8 under `flake8`:
 

--- a/docs/tools/ruby/brakeman.md
+++ b/docs/tools/ruby/brakeman.md
@@ -11,9 +11,9 @@ hide_title: true
 | ----------------- | -------- | -------- |
 | >= 4.0.0, < 4.4.0 (default to 4.3.1) | Ruby 2.5.1 | [https://brakemanscanner.org/](https://brakemanscanner.org/) |
 
-## Configuration via `sideci.yml`
+## Configuration via `sider.yml`
 
-Here are some example settings for Brakeman in `sideci.yml`, under `brakeman`:
+Here are some example settings for Brakeman in `sider.yml`, under `brakeman`:
 
 ```yaml
 linter:

--- a/docs/tools/ruby/haml-lint.md
+++ b/docs/tools/ruby/haml-lint.md
@@ -11,7 +11,7 @@ hide_title: true
 | ----------------- | -------- | -------- |
 | >= 0.26.0 (default to 0.32.0) | Ruby 2.5.1 | [https://github.com/sds/haml-lint](https://github.com/sds/haml-lint) |
 
-## Configuration via `sideci.yml`
+## Configuration via `sider.yml`
 
 Example settings for HAML-Lint under `haml_lint`:
 
@@ -51,7 +51,7 @@ You can use several options to fine-tune HAML-Lint to your project.
 
 Sider automatically finds and installs gems likely to be related to RuboCop from `Gemfile.lock`, but this behavior only works for backward compatibility. Therefore, this is skipped if you specify the `gems` option.
 
-We encourage you to explicitly specify gems in the [`gems` option](../../getting-started/custom-configuration.md#gems-option) in `sideci.yml`.
+We encourage you to explicitly specify gems in the [`gems` option](../../getting-started/custom-configuration.md#gems-option) in `sider.yml`.
 
 ## Default Configuration
 

--- a/docs/tools/ruby/querly.md
+++ b/docs/tools/ruby/querly.md
@@ -26,9 +26,9 @@ Visit the Querly project page for more information about writing rules:
  <iframe class="Video__iframe" src="https://www.youtube.com/embed/WtHmNuWJzPA" frameborder="0" allowfullscreen></iframe>
 </div>
 
-## Configuration via `sideci.yml`
+## Configuration via `sider.yml`
 
-Here are some example settings for Querly in `sideci.yml`, under `querly`:
+Here are some example settings for Querly in `sider.yml`, under `querly`:
 
 ```yaml
 linter:
@@ -52,4 +52,4 @@ Sider finds the following gems in `Gemfile.lock` and installs them automatically
 - [slim](https://github.com/slim-template/slim)
 - [haml](https://github.com/haml/haml)
 
-These gems are not installed automatically when the `gems` option is specified. We encourage you to explicitly specify gems in the [`gems` option](../../getting-started/custom-configuration.md#gems-option) in `sideci.yml`.
+These gems are not installed automatically when the `gems` option is specified. We encourage you to explicitly specify gems in the [`gems` option](../../getting-started/custom-configuration.md#gems-option) in `sider.yml`.

--- a/docs/tools/ruby/rails-bestpractices.md
+++ b/docs/tools/ruby/rails-bestpractices.md
@@ -11,9 +11,9 @@ hide_title: true
 | ----------------- | -------- | -------- |
 | >= 1.19.1, < 2.0 (default to 1.19.4) | Ruby 2.5.1 | [https://rails-bestpractices.com/](https://rails-bestpractices.com/) |
 
-## Configuration via `sideci.yml`
+## Configuration via `sider.yml`
 
-Here are some example settings for Rails Best Practices in `sideci.yml`, under `rails_best_practices`:
+Here are some example settings for Rails Best Practices in `sider.yml`, under `rails_best_practices`:
 
 ```yaml
 linter:
@@ -51,7 +51,7 @@ Rails Best Practices supports some template engines. Sider finds the following g
 - [sass](https://github.com/sass/ruby-sass)
 - [sassc](https://github.com/sass/sassc-ruby)
 
-These gems will not be installed when the `gems` option is specified. We encourage you to explicitly specify gems in the [`gems` option](../../getting-started/custom-configuration.md#gems-option) in `sideci.yml` as follows:
+These gems will not be installed when the `gems` option is specified. We encourage you to explicitly specify gems in the [`gems` option](../../getting-started/custom-configuration.md#gems-option) in `sider.yml` as follows:
 
 ```yaml
 linter:

--- a/docs/tools/ruby/reek.md
+++ b/docs/tools/ruby/reek.md
@@ -11,9 +11,9 @@ hide_title: true
 | ----------------- | -------- | -------- |
 | >= 4.4.0, < 6.0 (default to 5.4.0) | Ruby 2.5.1 | [https://github.com/troessner/reek](https://github.com/troessner/reek) |
 
-## Configuration via `sideci.yml`
+## Configuration via `sider.yml`
 
-Here are some example settings for Reek in `sideci.yml`, under `reek`:
+Here are some example settings for Reek in `sider.yml`, under `reek`:
 
 ```yaml
 linter:

--- a/docs/tools/ruby/rubocop.md
+++ b/docs/tools/ruby/rubocop.md
@@ -11,7 +11,7 @@ hide_title: true
 | ----------------- | -------- | -------- |
 | >= 0.35.0 (default to 0.71.0) | Ruby 2.5.1 | [https://github.com/rubocop-hq/rubocop](https://github.com/rubocop-hq/rubocop) |
 
-## Configuration via `sideci.yml`
+## Configuration via `sider.yml`
 
 Example settings for RuboCop under `rubocop`:
 
@@ -57,7 +57,7 @@ This option controls to cops RuboCop inspects. If `true`, RuboCop will inspect c
 
 Sider automatically finds and installs gems likely to be related to RuboCop from `Gemfile.lock`, but this behavior only works for backward compatibility. Therefore, this is skipped if you specify the `gems` option.
 
-We encourage you to explicitly specify gems in the [`gems` option](../../getting-started/custom-configuration.md#gems-option) in `sideci.yml`.
+We encourage you to explicitly specify gems in the [`gems` option](../../getting-started/custom-configuration.md#gems-option) in `sider.yml`.
 
 ## Default Configuration
 

--- a/docs/tools/swift/swiftlint.md
+++ b/docs/tools/swift/swiftlint.md
@@ -17,7 +17,7 @@ To start using SwiftLint, enable it in [Repository Settings](../../getting-start
 
 To customize SwiftLint, put a `.swiftlint.yml` file in your repository.
 
-## Configuration via `sideci.yml`
+## Configuration via `sider.yml`
 
 Here are example settings for SwiftLint under `swiftlint`:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -49,7 +49,7 @@ You can also disable Sider for the repository if you are an admin of the reposit
 ## Why did a pull request fail to checkout?
 In many cases, the checkout failed will be resolved by retrying. However, if the error occurs in spite of several retries, the cause of the error is possible that the analyses have been taken a lot of time.
 
-You can ignore specific files to fix the problem. Write the settings to `sideci.yml` like below:
+You can ignore specific files to fix the problem. Write the settings to `sider.yml` like below:
 
 ```yaml
 linter:

--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -1,4 +1,14 @@
-rules: []
+rules:
+  - id: review.sider.help.sideci.yml
+    pattern: sideci.yml
+    message: |
+      Prefer `sider.yml` over `sideci.yml`
+
+      `sideci.yml` is supported for the backward compatibility, but Sider recognizes `sider.yml` more preferentially.
+      Please use `sider.yml` in the documentation.
+    example:
+      - before: sideci.yml
+        after: sider.yml
 
 import:
   - https://raw.githubusercontent.com/sider/goodcheck-rules/master/rules/typo.yml


### PR DESCRIPTION
Renamed `sideci.yml` to `sider.yml`.

For the backward compatibility, `sideci.yml` is still supported. But Sider recognizes `sider.yml` if `sider.yml` and `sideci.yml` both exist.