### PR TITLE
Add note about `--rails` option after v0.72.0

### DIFF
--- a/docs/tools/ruby/rubocop.md
+++ b/docs/tools/ruby/rubocop.md
@@ -37,6 +37,8 @@ linter:
 
 #### `rails`
 
+> The option is ignored after `0.72.0`. Please use `rubocop-rails` plugin instead.
+
 This option controls whether to run Rails Cops. If it is omitted, Sider automatically determines whether to run Rails Cops or not.
 
 This option is used for the case that you do not wish Sider to run Rails Cops even though your project is a Ruby on Rails project.

--- a/docs/tools/ruby/rubocop.md
+++ b/docs/tools/ruby/rubocop.md
@@ -37,7 +37,7 @@ linter:
 
 #### `rails`
 
-> The option is ignored after `0.72.0`. Please use `rubocop-rails` plugin instead.
+> The option is ignored after the version `0.72.0`. Please use the [`rubocop-rails`](https://github.com/rubocop-hq/rubocop-rails) plugin instead.
 
 This option controls whether to run Rails Cops. If it is omitted, Sider automatically determines whether to run Rails Cops or not.
 


### PR DESCRIPTION
`--rails` option was removed in RuboCop v0.72.0. See https://github.com/rubocop-hq/rubocop/pull/7095

Sider already has been ignored the option if a user is using RuboCop v0.72.0 or later. This PR updates documentation to describe the behavior.