### PR TITLE
Fix CoffeeLint homepage URL

### DIFF
--- a/docs/tools/javascript/coffeelint.md
+++ b/docs/tools/javascript/coffeelint.md
@@ -9,7 +9,7 @@ hide_title: true
 
 | Supported Version | Language | Web Site |
 | ----------------- | -------- | -------- |
-| 1.16.0 | JavaScript(Node.js 11.5.0) | https://github.com/jashkenas/coffeescript |
+| 1.16.0 | JavaScript(Node.js 11.5.0) | https://github.com/clutchski/coffeelint |
 
 ## Getting Started
 

--- a/docs/tools/javascript/coffeelint.md
+++ b/docs/tools/javascript/coffeelint.md
@@ -9,7 +9,7 @@ hide_title: true
 
 | Supported Version | Language | Web Site |
 | ----------------- | -------- | -------- |
-| 1.16.0 | JavaScript(Node.js 11.5.0) | [http://www.coffeelint.org/](http://www.coffeelint.org/) |
+| 1.16.0 | JavaScript(Node.js 11.5.0) | https://github.com/jashkenas/coffeescript |
 
 ## Getting Started
 


### PR DESCRIPTION
The homepage URL <http://www.coffeelint.org/> has been down, so this changes it to the GitHub repository URL.

Related issue: https://github.com/clutchski/coffeelint/issues/643