### PR TITLE
Specify default configuration instead of sideci_config

### DIFF
--- a/docs/tools/go/gometalinter.md
+++ b/docs/tools/go/gometalinter.md
@@ -33,9 +33,29 @@ If `glide.yaml` contains a dependency to a library in a private repository, plea
 
 ## Default Configuration
 
-If your `sider.yml` does not contain `config` option, Sider will use the default configuration. The default configuration is available in our repository.
+If your `sider.yml` does not contain the [`config`](#config) option, Sider will use the default configuration as follows:
 
-* [Sider's configuration for Go Meta Linter](https://github.com/actcat/sideci_config/blob/master/go/gometalinter/gometalinter.json)
+```json
+{
+  "Linters": {
+    "gosec": "gosec -fmt=csv -exclude=G103,G104,G201,G202,G204,G301,G302 {path}/*.go:^(?P<path>.*?\\.go),(?P<line>\\d+),(?P<message>[^,]+,[^,]+,[^,]+)"
+  },
+  "Disable": [
+    "aligncheck",
+    "structcheck",
+    "varcheck",
+    "dupl",
+    "errcheck",
+    "goimports",
+    "golint",
+    "gotype",
+    "lll",
+    "misspell",
+    "vetshadow"
+  ],
+  "Cyclo": 15
+}
+```
 
 ## Configuration via `sider.yml`
 

--- a/docs/tools/javascript/eslint.md
+++ b/docs/tools/javascript/eslint.md
@@ -31,9 +31,14 @@ If you need more customization, use standard ESLint config files. For instance, 
 
 ## Default Configuration
 
-Sider provides a recommended configuration for ESLint. The configuration is used when you haven't added any ESLint configurations in your `sider.yml` and don't have the default config files, `.eslintrc`, `.eslintrc.yml`, `.eslintrc.yaml`, or `.eslintrc.json` in your repository.
+Sider prepares the following configuration to default. The configuration is used when you haven't added any ESLint configurations in your `sider.yml` and don't have the default config files, `.eslintrc`, `.eslintrc.yml`, `.eslintrc.yaml`, or `.eslintrc.json` in your repository.
 
-* [Sider recommended settings for ESLint](https://github.com/actcat/sideci_config/blob/master/javascript/eslint/eslintrc)
+```yaml
+extends: 'eslint:recommended'
+rules:
+  no-undef: off
+  no-unused-vars: off
+```
 
 ## Configuration via `sider.yml`
 

--- a/docs/tools/javascript/jshint.md
+++ b/docs/tools/javascript/jshint.md
@@ -19,9 +19,29 @@ To customize the configuration, use the standard `.jshintrc` or `.jshintignore` 
 
 ## Default Configuration
 
-Sider uses its default configuration where there is no custom configuration preset:
+Sider uses the default configuration where there is no custom configuration preset. The configuration is here:
 
-* [Sider's configuration for jshintrc](https://github.com/actcat/sideci_config/blob/master/javascript/jshint/sideci_jshintrc)
+```json5
+{
+  // Relaxes
+  "asi": true,
+  "sub": true,
+  "eqnull": true,
+
+  // Environments
+  "jquery": true,
+  "browser": true,
+
+  "esversion": 2015
+}
+```
+
+In addition, we uses `.jshintignore` to default with following setting:
+
+```
+public/js/**/*.js
+**/*.min.js
+```
 
 ## Configuration via `sider.yml`
 

--- a/docs/tools/php/phpmd.md
+++ b/docs/tools/php/phpmd.md
@@ -45,9 +45,38 @@ linter:
 
 ## Default Configuration
 
-If you leave the `rule` option undefined in `sider.yml`, Sider runs PHPMD with our recommended settings. The recommended settings are available in our GitHub repository:
+If you leave the `rule` option undefined in `sider.yml`, Sider runs PHPMD with the following configuration to default:
 
-* [Sider recommended settings for PHPMD](https://github.com/actcat/sideci_config/blob/master/php/phpmd/sideci_config.xml)
+```xml
+<?xml version="1.0"?>
+<ruleset name="Sider Recommended ruleset"
+         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0
+                     http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation="
+                     http://pmd.sf.net/ruleset_xml_schema.xsd">
+  <description>
+    This ruleset is recommended by Sider.
+    It contains only generic rules in all projects.
+  </description>
+
+  <rule ref="rulesets/codesize.xml">
+    <exclude name="NPathComplexity"></exclude>
+  </rule>
+  <rule ref="rulesets/controversial.xml">
+    <exclude name="CamelCaseClassName"></exclude>
+    <exclude name="CamelCasePropertyName"></exclude>
+    <exclude name="CamelCaseMethodName"></exclude>
+    <exclude name="CamelCaseParameterName"></exclude>
+    <exclude name="CamelCaseVariableName"></exclude>
+  </rule>
+  <rule ref="rulesets/design.xml" />
+  <rule ref="rulesets/unusedcode.xml">
+    <exclude name="UnusedFormalParameter"></exclude>
+  </rule>
+</ruleset>
+```
 
 ## Configuration via `sider.yml`
 

--- a/docs/tools/python/flake8.md
+++ b/docs/tools/python/flake8.md
@@ -27,9 +27,28 @@ The latest versions of Python 2 or Python 3 can be used.
 
 Sider provides a default configuration for Flake8. If your repository does not include `.flake8`, `setup.cfg` or `tox.ini`, our default configuration will be used.
 
-Our default configuration is available here:
+Our default configuration is here:
 
-* [Sider's configuration for Flake8](https://github.com/actcat/sideci_config/blob/master/python/flake8/sideci_config.ini)
+```ini
+[flake8]
+ignore =
+  # Ignore all warnings
+  W,
+  # Ignore all indentation rules
+  E1,
+  # Ignore all whitespace rules
+  E2,
+  # Ignore all blank line rules
+  E3,
+  # Ignore all import rules
+  E4,
+  # Ignore backslash style rule
+  E502,
+  # Ignore oneline statement rules
+  E70,
+
+max-line-length = 200
+```
 
 ## Configuration via `sider.yml`
 


### PR DESCRIPTION
We have https://github.com/actcat/sideci_config as our service's default configuration settings.
However, it is too old to run on our documents because the settings were published for our ancient systems.

Thus, I specify default settings not but sideci_config URL.