### PR TITLE
Update description about npm analyzers

### DIFF
--- a/docs/getting-started/custom-configuration.md
+++ b/docs/getting-started/custom-configuration.md
@@ -22,7 +22,7 @@ linter:
 
   eslint:
     root_dir: 'frontend'
-    npm_install: true
+    npm_install: false
     config: 'frontend/.eslintrc'
     ext: 'js,jsx'
 
@@ -140,6 +140,40 @@ linter:
 | `ref` | `string` | Ref name. |
 
 If you would like to install a gem located in a private git repository, see [private dependencies guide](../advanced-settings/private-dependencies.md) and configure SSH key.
+
+## `npm_install` option
+
+For npm-published analyzers such as [ESLint](../tools/javascript/eslint.md) or [stylelint](../tools/css/stylelint.md), you can use the `npm_install` option to configure the behavior of npm dependencies installation. This option has the following values:
+
+| Value            | Description |
+| ---------------- | ----------- |
+| `true` (default) | Install dependencies via [npm](https://docs.npmjs.com/) or [Yarn](https://yarnpkg.com). |
+| `false`          | Do not install any dependencies. |
+| `"production"`   | Install only dependencies for production. |
+| `"development"`  | Install only dependencies for development. |
+| Others           | Fail analysis. |
+
+For example:
+
+```yaml
+linter:
+  eslint:
+    npm_install: "development"
+  stylelint:
+    npm_install: false
+```
+
+When the `npm_install` option is except for `false`, Sider will try as follows:
+
+1. Check if `package.json` exists. If not present, Sider uses the default version of the analyzers.
+2. If `package.json` and `yarn.lock` exist, Sider runs the [`yarn install`](https://yarnpkg.com/lang/en/docs/cli/install/) command.
+3. If `package.json` and `package-lock.json` exist, Sider runs the [`npm ci`](https://docs.npmjs.com/cli/ci) command.
+4. If `package.json` exists but none of `yarn.lock` and `package-lock.json` exist, Sider runs the [`npm install`](https://docs.npmjs.com/cli/install) command.
+5. Checks if the analyzer is installed in the `node_modules` directory.
+6. If installed, Sider uses the installed version.
+7. If not installed (for any reason), Sider uses the pre-installed default version.
+
+On the other hand, when the `npm_install` option is `false`, Sider will skip these installation steps and analyze with the pre-installed default version.
 
 ## `ignore` option
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,16 @@ This section has documents about analysis tools which Sider supports. We have an
 
 </details>
 
+### CSS
+
+<details open>
+  <summary>2 tools are available.</summary>
+
+  * [stylelint](./tools/css/stylelint.md)
+  * [SCSS-Lint](./tools/css/scss-lint.md)
+
+</details>
+
 ### PHP
 
 <details open>
@@ -90,16 +100,6 @@ This section has documents about analysis tools which Sider supports. We have an
   <summary>1 tool is available.</summary>
 
   * [SwiftLint](./tools/swift/swiftlint.md)
-
-</details>
-
-### CSS
-
-<details open>
-  <summary>2 tools are available.</summary>
-
-  * [stylelint](./tools/css/stylelint.md)
-  * [SCSS-Lint](./tools/css/scss-lint.md)
 
 </details>
 
@@ -142,7 +142,7 @@ This section covers advanced features outside of the basic setup of Sider.
 
 ## Billing and Plans
 
-This section covers questions about billing, invoices, and plans. 
+This section covers questions about billing, invoices, and plans.
 
 * [Billing and Plans](./billing-and-plans.md)
 

--- a/docs/tools/css/stylelint.md
+++ b/docs/tools/css/stylelint.md
@@ -7,96 +7,90 @@ hide_title: true
 
 # stylelint
 
-| Supported Version | Language | Web Site |
-| ----------------- | -------- | -------- |
-| Optional (default to 10.1.0) | CSS / Any languages that PostCSS can parse<br />(e.g. SCSS, SugarSS and Less) | [https://stylelint.io/](https://stylelint.io/) |
+| Supported Version          | Language                    | Runtime        | Website              |
+| -------------------------- | --------------------------- | -------------- | -------------------- |
+| 8.3.0+ (default to 10.1.0) | CSS and flavors (e.g. Sass) | Node.js 12.7.0 | https://stylelint.io |
 
 ## Getting Started
 
-To start using stylelint, enable it in [Repository Settings](../../getting-started/repository-settings.md) and declare it as a dependency in your `package.json`:
+To start using stylelint, enable it in your [repository settings](../../getting-started/repository-settings.md).
 
-```bash
-$ npm install stylelint -D
+If you want to use a version except for the Sider default version or use some plugins or shareable configurations, install it into your repository as follows:
+
+```shell
+$ npm install stylelint --save-dev
+
+$ npm install stylelint-config-standard --save-dev
 ```
 
 Sider supports styelint plugins and configurations that are provided as npm packages.
 
-If you need more customization, use the standard stylelint config files. For example, use `.stylelintrc.yaml` to customize rules, and `.stylelintignore` to ignore files and directories.
+If you need more customization, use the standard stylelint configuration files. For example, use `.stylelintrc.yaml` to customize rules, and `.stylelintignore` to ignore files and directories.
 
 ## Default Configuration
 
-If you don't have any custom configuration defined, Sider uses the latest version of [stylelit-config-recommended](https://github.com/stylelint/stylelint-config-recommended).
+If you have no custom configuration, Sider uses the latest version of [stylelint-config-recommended](https://github.com/stylelint/stylelint-config-recommended).
+
+```yaml
+extends: "stylelint-config-recommended"
+```
+
+Also, Sider ignores `*.min.css` files by default.
 
 ## Configuration via `sider.yml`
 
-Here are example settings for stylelint under `stylelint`:
+Here are an example settings for stylelint:
 
 ```yaml
 linter:
   stylelint:
-    npm_install: true
-    config: lint_yml/mystylelintrc.yaml
-    ignore-path: .gitignore
+    npm_install: false
+    config: my_stylelintrc.yaml
     syntax: sugarss
+    ignore-path: .gitignore
     ignore-disables: true
     report-needless-disables: true
     quiet: true
-    glob: '**/*.{css,scss}'
+    glob: "**/*.{css,scss}"
 ```
 
-### Options
+You can use the following options to fine-tune stylelint to your project.
 
-You can use several options to fine-tune stylelint to your project.
+| Name                                                    | Type      | Default                         | Description                                                                                                          |
+| ------------------------------------------------------- | --------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `npm_install`                                           | -         | -                               | See [here](../../getting-started/custom-configuration.md#npm_install-option).                                        |
+| [`config`](#config)                                     | `string`  | -                               | [`--config`](https://stylelint.io/user-guide/node-api#configfile) option of stylelint.                               |
+| [`syntax`](#syntax)                                     | `string`  | -                               | [`--syntax`](https://stylelint.io/user-guide/node-api#syntax) option of stylelint.                                   |
+| [`ignore-path`](#ignore-path)                           | `string`  | -                               | [`--ignore-path`](https://stylelint.io/user-guide/node-api#ignorepath) option of stylelint.                          |
+| [`ignore-disables`](#ignore-disables)                   | `boolean` | `false`                         | [`--ignore-disables`](https://stylelint.io/user-guide/node-api#ignoredisables) option of stylelint.                  |
+| [`report-needless-disables`](#report-needless-disables) | `boolean` | `false`                         | [`--report-needless-disables`](https://stylelint.io/user-guide/node-api#reportneedlessdisables) option of stylelint. |
+| [`quiet`](#quiet)                                       | `boolean` | `false`                         | [`--quiet`](https://stylelint.io/user-guide/node-api#quiet) option of stylelint.                                     |
+| [`glob`](#glob)                                         | `string`  | `**/*.{css,less,sass,scss,sss}` | A glob pattern to analyze.                                                                                           |
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [`npm_install`](#npm_install) | `boolean`,<br>`string` | Run `npm install` before analysis. |
-| [`config`](#config) | `string` | Set the configuration file for stylelint. |
-| [`syntax`](#syntax) | `string` | Set a non-standard syntax for PostCSS. |
-| [`ignore-path`](#ignore-path) | `string` | Set the path to the ignore file. |
-| [`ignore-disables`](#ignore-disables) | `boolean` | If `true`, stylelint will ignore all `stylelint-disable` comments. |
-| [`report-needless-disables`](#report-needless-disables) | `boolean` | If `true`, `stylelint-disable` comments will be reported. |
-| [`quiet`](#quiet) | `boolean` | If `true`, rules less severe than 'error' will be ignored. |
-| [`glob`](#glob) | `string` | Specify the file extensions inspected by stylelint. |
+### `config`
 
-#### `npm_install`
+This option allows you to specify a configuration file except for the stylelint default file (e.g. `.stylelintrc.json`).
 
-This option allows you to use `npm install` to install dependencies before analysis starts.
+### `syntax`
 
-| Value | Execution Command |
-| :---- | :---------------- |
-| `true` | `npm install --ignore-scripts` |
-| `false` | None. |
-| `development` | `npm install --only=development --ignore-scripts` |
-| `production` | `npm install --only=production --ignore-scripts` |
-| Other values | Sider analysis fails. |
+This option allows you to control the non-standard syntaxes (e.g. `css-in-js`). In contrast, stylelint will automatically infer the standard syntaxes.
 
-Note that if your `package.json` contains dependecies which cannot be installed in the Sider container, `npm install` will fail. In this case, try using the `development` or `production` option. You can also make the failing dependency an `optionalDependency`.
+### `ignore-path`
 
-#### `config`
+This option allows you to exclude files from analysis. By default stylelint uses a `.stylelintignore` file, but if you want to use another file, set this option. For more details, see [the stylelint documentation](https://stylelint.io/user-guide/configuration#stylelintignore).
 
-This option allows you to specify a configuration file for stylelint. If you have your own settings file for stylelint, use this option. The valid extensions for `stylelintrc` are `.yml`, `.yaml`, `.json` and `.js`. You can also use `.stylelintc` and `package.json` for configuration.
+### `ignore-disables`
 
-#### `syntax`
+This option allows you to ignore all disable comments, i.e. `/* stylelint-disable block-no-empty */`.
 
-This option allows you to control the non-standard syntaxes analyzed by PostCSS. You can specify `scss`, `sass`, `less` or `sugarss`. By default, non-standard syntaxes such as `.scss`, `.sass`, `.less` and `.sss` files are detected.
-
-#### `ignore-path`
-
-This option allows you to exclude files from analysis. By default stylelint detects and uses `.stylelintrc`, even if this option isn't set. If you'd like to use other ignore files, such as `.gitignore`, `.eslintignore` and so on, put them in this option.
-
-#### `ignore-disables`
-
-This option allows you to ignore all disable comments, i.e. `/* stylelint-disable block-no-empty */`. If you would like to ignore these comments, set this to `true`.
-
-#### `report-needless-disables`
+### `report-needless-disables`
 
 This option allows you to control whether `stylelint-disable` comments are reported or not.
 
-#### `quiet`
+### `quiet`
 
 This option allows you to ignore warnings and only report errors.
 
-#### `glob`
+### `glob`
 
-This option allows you to specify the file extensions which are inspected by stylelint. By default, `**/*.{css,less,sass,scss,sss}` files are included.
+This option allows you to specify the files or directories to analyze.

--- a/docs/tools/css/stylelint.md
+++ b/docs/tools/css/stylelint.md
@@ -39,7 +39,7 @@ Also, Sider ignores `*.min.css` files by default.
 
 ## Configuration via `sider.yml`
 
-Here are an example settings for stylelint:
+Here is an example for stylelint:
 
 ```yaml
 linter:

--- a/docs/tools/javascript/coffeelint.md
+++ b/docs/tools/javascript/coffeelint.md
@@ -5,48 +5,41 @@ sidebar_label: CoffeeLint
 hide_title: true
 ---
 
-# CoffeLint
+# CoffeeLint
 
-| Supported Version | Language | Website |
-| ----------------- | -------- | -------- |
-| 1.16.0 | JavaScript (Node.js 12.7.0) | https://github.com/clutchski/coffeelint |
+| Supported Version           | Language     | Runtime        | Website                                 |
+| --------------------------- | ------------ | -------------- | --------------------------------------- |
+| 1.16.0+ (default to 1.16.0) | CoffeeScript | Node.js 12.7.0 | https://github.com/clutchski/coffeelint |
 
 ## Getting Started
 
-To start using CoffeeLint, enable it in [Repository Settings](../../getting-started/repository-settings.md).
+To start using CoffeeLint, enable it in your [repository settings](../../getting-started/repository-settings.md).
+
+If you want to use a version except for the Sider default version, install it into your repository:
+
+```shell
+$ npm install coffeelint --save-dev
+```
+
+Then, create your `coffeelint.json` file and edit it.
 
 ## Configuration via `sider.yml`
 
-Here are example settings for CoffeeLint:
+Here are an example settings for CoffeeLint:
 
 ```yaml
 linter:
   coffeelint:
-    npm_install: true
-    file: coffeelint.json
+    file: my_coffeelint.json
 ```
 
-### Options
+You can use the following options to make analysis fitter for your project.
 
-You can use several options to make analysis fitter for your project.
+| Name            | Type     | Default | Description                                                                   |
+| --------------- | -------- | ------- | ----------------------------------------------------------------------------- |
+| `npm_install`   | -        | -       | See [here](../../getting-started/custom-configuration.md#npm_install-option). |
+| [`file`](#file) | `string` | -       | Set your configuration file.                                                  |
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [`npm_install`](#npm_install) | `boolean`,<br />`string` | Resolve dependencies when analyzing with `npm`. |
-| [`file`](#file) | `string` | Set configuration file for CoffeeLint. |
+### `file`
 
-#### `npm_install`
-
-By using this option, you can install coffeelint and dependencies before analysis. This means you can install the version of CoffeeScript specified in `package.json`.
-
-| Value | Execution Command |
-| :---- | :---------------- |
-| `true` | `npm install --ignore-scripts` |
-| `false` | None. |
-| `development` | `npm install --only=development --ignore-scripts` |
-| `production` | `npm install --only=production --ignore-scripts` |
-| Other values | Sider analysis fails. |
-
-#### `file`
-
-This option controls the configuration file. If you have a `coffeelint.json` file, put the path to the file here. This option is not required.
+This option allows you to specify your own configuration file. If you want to use a configuration file except for the default `coffeelint.json` file, set this option.

--- a/docs/tools/javascript/coffeelint.md
+++ b/docs/tools/javascript/coffeelint.md
@@ -25,7 +25,7 @@ Then, create your `coffeelint.json` file and edit it.
 
 ## Configuration via `sider.yml`
 
-Here are an example settings for CoffeeLint:
+Here is an example for CoffeeLint:
 
 ```yaml
 linter:

--- a/docs/tools/javascript/eslint.md
+++ b/docs/tools/javascript/eslint.md
@@ -55,7 +55,7 @@ rules:
 
 ## Configuration via `sider.yml`
 
-Here are an example settings for ESLint:
+Here is an example for ESLint:
 
 ```yaml
 linter:

--- a/docs/tools/javascript/eslint.md
+++ b/docs/tools/javascript/eslint.md
@@ -7,34 +7,47 @@ hide_title: true
 
 # ESLint
 
-| Supported Version | Language | Website |
-| ----------------- | -------- | -------- |
-| Optional (default to 5.16.0) | JavaScript (Node.js 12.7.0) | https://eslint.org |
+| Supported Version           | Language   | Runtime        | Website            |
+| --------------------------- | ---------- | -------------- | ------------------ |
+| 3.19.0+ (default to 5.16.0) | JavaScript | Node.js 12.7.0 | https://eslint.org |
 
 ## Getting Started
 
-To start using ESLint in Sider, declare it as a dependency in your `package.json`.
+To start using ESLint, enable it in your [repository settings](../../getting-started/repository-settings.md).
+After enabled, Sider will automatically analyze your JavaScript files with the default version and [default configuration](#default-configuration). Or if you already have configured ESLint, Sider will install your dependencies and analyze with your configuration.
 
-```bash
-$ npm install eslint -D
+But if you want to customize more ESLint with some plugins or shareable configurations, install ESLint first:
+
+```shell
+$ npm install eslint --save-dev
 ```
 
-Add `sider.yml` to your repository:
+For example if you are using React, you may need the ESLint plugin for React:
+
+```shell
+$ npm install eslint-plugin-react --save-dev
+```
+
+Next, you may have to create your `.eslintrc.*` file(s) and configure ESLint with them.
+For more details, see [the ESLint documentation](https://eslint.org/docs/user-guide/getting-started).
+
+Then, if you need more customization, you can do it by adding a `sider.yml` file to your repository. For example, if you want to analyze React files in a `frontend/` directory, you may configure your `sider.yml` as follows:
 
 ```yaml
 linter:
   eslint:
-    npm_install: true
+    dir: "frontend/"
+    ext: ".js,.jsx"
 ```
 
-If you need more customization, use standard ESLint config files. For instance, use `.eslintrc` to customize rules, and `.eslintignore` to specify files to ignore during analysis.
+For more details, see the following sections.
 
 ## Default Configuration
 
-Sider prepares the following configuration to default. The configuration is used when you haven't added any ESLint configurations in your `sider.yml` and don't have the default config files, `.eslintrc`, `.eslintrc.yml`, `.eslintrc.yaml`, or `.eslintrc.json` in your repository.
+Sider prepares the following configuration by default. The configuration is used when you have no ESLint configurations in your repository or `sider.yml`.
 
 ```yaml
-extends: 'eslint:recommended'
+extends: "eslint:recommended"
 rules:
   no-undef: off
   no-unused-vars: off
@@ -42,57 +55,40 @@ rules:
 
 ## Configuration via `sider.yml`
 
-Put settings for ESLint under `eslint`:
+Here are an example settings for ESLint:
 
 ```yaml
 linter:
   eslint:
-    npm_install: true
     dir: frontend/app
-    config: '.myeslintrc'
-    ext: '.js,.jsx,.es6'
-    ignore-path: .gitignore
+    config: .my_eslintrc
+    ext: ".js,.jsx,.es6"
+    ignore-path: .my_eslintignore
     no-ignore: true
-    ignore-pattern: /src/vendor/*
-    global: require,exports:true welcome.js
+    ignore-pattern: "/src/vendor/*"
+    global: "require,exports:true"
     quiet: true
 ```
 
-### Options
+You can use the following options to make analysis fitter for your project.
 
-You can use several options to make analysis fitter for your project.
+| Name                                | Type                      | Default | Description                                                                                                        |
+| ----------------------------------- | ------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
+| `npm_install`                       | -                         | -       | See [here](../../getting-started/custom-configuration.md#npm_install-option).                                      |
+| [`dir`](#dir)                       | `string`, `array<string>` | `.`     | Directories to analyze.                                                                                            |
+| [`config`](#config)                 | `string`                  | -       | [`--config`](https://eslint.org/docs/user-guide/command-line-interface#-c---config) option of ESLint.              |
+| [`ext`](#ext)                       | `string`                  | `.js`   | [`--ext`](https://eslint.org/docs/user-guide/command-line-interface#--ext) option of ESLint.                       |
+| [`ignore-path`](#ignore-path)       | `string`                  | -       | [`--ignore-path`](https://eslint.org/docs/user-guide/command-line-interface#--ignore-path) option of ESLint.       |
+| [`no-ignore`](#no-ignore)           | `boolean`                 | `false` | [`--no-ignore`](https://eslint.org/docs/user-guide/command-line-interface#--no-ignore) option of ESLint.           |
+| [`ignore-pattern`](#ignore-pattern) | `string`, `array<string>` | -       | [`--ignore-pattern`](https://eslint.org/docs/user-guide/command-line-interface#--ignore-pattern) option of ESLint. |
+| [`global`](#global)                 | `string`                  | -       | [`--global`](https://eslint.org/docs/user-guide/command-line-interface#--global) option of ESLint.                 |
+| [`quiet`](#quiet)                   | `boolean`                 | `false` | [`--quiet`](https://eslint.org/docs/user-guide/command-line-interface#--quiet) option of ESLint.                   |
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [`npm_install`](#npm_install) | `boolean`,<br />`string` | Resolve dependencies when analyzing with `npm`. |
-| [`dir`](#dir) | `string`,<br />`array<string>` | Set files or directories name to analyze. |
-| [`config`](#config) | `string` | Set configuration file for ESLint. |
-| [`ext`](#ext) | `string` | Specify file extensions inspected by ESLint. |
-| [`ignore-path`](#ignore-path) | `string` | Set ignore file as necessary to exclude files from analysis. |
-| [`ignore-pattern`](#ignore-pattern) | `string`,<br />`array<string>` | Set ignore patterns to exclude files from analysis. |
-| [`no-ignore`](#no-ignore) | `boolean` | If `true`, disable excluded files from ignore settings of ESLint. |
-| [`global`](#global) | `string` | Define global variables with this option. |
-| [`quiet`](#quiet) | `boolean` | If `true`, ESLint reports only error. |
+For details of the options, check the following sections and [the ESLint documentation](https://eslint.org/docs/user-guide/command-line-interface#options).
 
-For details of the options, check following items.
+### `dir`
 
-#### `npm_install`
-
-This option controls `npm` command invocation. Using this option, you can install dependencies before analysis.
-
-| Value | Execution Command |
-| :---- | :---------------- |
-| `true` | `npm install --ignore-scripts` |
-| `false` | None. |
-| `development` | `npm install --only=development --ignore-scripts` |
-| `production` | `npm install --only=production --ignore-scripts` |
-| Other values | Sider analysis fails. |
-
-If your `package.json` contains a dependency which cannot be installed in the Sider container, `npm install` fails. The analysis will continue, but the results may be inaccurate. In this case, try using the `development` or `production` options, or set the dependency as an `optionalDependency`.
-
-#### `dir`
-
-This option controls name of directory to pass to `eslint`. The default value is `.`. Declare directory to analyze like this:
+This option allows you to specify a directory to analyze. For example:
 
 ```yaml
 linter:
@@ -100,7 +96,7 @@ linter:
     dir: frontend/src
 ```
 
-If you would like to analyze multiple directories with Sider, you can set them like this:
+Also, you can specify multiple directories or glob patterns:
 
 ```yaml
 linter:
@@ -108,58 +104,33 @@ linter:
     dir:
       - frontend/src
       - app/assets/javascripts
-      - public/assets/javascripts
+      - "**/__tests__/**"
 ```
 
-#### `config`
+### `config`
 
-This option allows you specify an additional configuration file. ESLint uses your `.eslintrc{.yaml,.yml,.json}` in the root directory of your project by default, so you don't need to use this option if you have used one of the default filenames. If your ESLint config file has a different name, or is not in the root directory, you should use this option:
+This option allows you to specify an additional configuration file.
 
-```yaml
-linter:
-  eslint:
-    options:
-      config: lint_yml/.eslintrc
-```
+### `ext`
 
-#### `ext`
+This option allows you to specify file extensions to analyze.
 
-This option controls file extensions. By default, only `.js` files are inspected.
+### `ignore-path`
 
-#### `ignore-path`
+This option allows you to exclude files from analysis by your ignore file.
 
-This option allows you to exclude files from analysis. By default ESLint detects and uses `.eslintrc` even if you don't use this option. If you'd like to use other ignore files, such as `.gitignore`, put them in this option.
+### `no-ignore`
 
-#### `no-ignore`
+This option allows you to disable the use of ignore files or patterns.
 
-This option controls use of ignore files or patterns to disable.
+### `ignore-pattern`
 
-#### `ignore-pattern`
+This option allows you to ignore files by patterns.
 
-This option allows you to ignore files by pattern. It must be a string or an array.
+### `global`
 
-#### `global`
+This option allows you to define global variables. It requires a comma-separated string.
 
-This option controls definition of global variables. It requires a comma-separated string.
+### `quiet`
 
-Please see here to learn more about ESLint's command line interface: [ESLint - Command Line Interface](https://eslint.org/docs/user-guide/command-line-interface).
-
-#### `quiet`
-
-This option controls warnings. When `true`, ESLint will only report errors (and ignore warnings).
-
-## Troubleshooting
-
-### What if our repo does not have `package.json`?
-
-> We generally recommend using `npm install` to install dependencies. This standard way allows us to handle your dependencies correctly. This way, we'll never install an ESLint version different from the one you want to use.
->
-> However, we also try to install dependencies even if `package.json` cannot be found in your repository. This mechanism is for backward compatibility. It is unstable and unreliable, and we are no longer actively supporting it.
->
-> Put `package.json` in your repository and set  `npm_install: true`. This is stable and future-proof.
-
-If your repository does not contain a `package.json` or have `npm_install:` set to `true`, Sider tries to install required npm packages as the following:
-
-1. Read `eslintrc` \(or equivalent\) and find plugins, parsers, and configurations to install
-2. Try installing the `@latest` of the libraries and their peer dependencies
-3. Install `eslint@latest` if `eslint` is not yet installed
+This option allows you to suppress warnings. When `true`, only errors are reported.

--- a/docs/tools/javascript/tslint.md
+++ b/docs/tools/javascript/tslint.md
@@ -46,7 +46,7 @@ Sider prepares the following configuration by default. Sider uses the configurat
 
 ## Configuration via `sider.yml`
 
-Here are an example settings for TSLint:
+Here is an example for TSLint:
 
 ```yaml
 linter:

--- a/docs/tools/javascript/tslint.md
+++ b/docs/tools/javascript/tslint.md
@@ -7,93 +7,94 @@ hide_title: true
 
 # TSLint
 
-| Supported Version | Language | Website |
-| ----------------- | -------- | -------- |
-| Optional (default to 5.18.0) | JavaScript (Node.js 12.7.0) | https://palantir.github.io/tslint |
+| Supported Version          | Language   | Runtime        | Website                           |
+| -------------------------- | ---------- | -------------- | --------------------------------- |
+| 5.0.0+ (default to 5.18.0) | TypeScript | Node.js 12.7.0 | https://palantir.github.io/tslint |
 
 ## Getting Started
 
-To start using TSLint in Sider, declare it as a dependency in `package.json` in your repository.
+To start using TSLint, enable it in your [repository settings](../../getting-started/repository-settings.md).
+After enabled, Sider will automatically analyze your TypeScript files with the default version and [default configuration](#default-configuration). Or if you already have configured TSLint, Sider will install your dependencies and analyze with your configuration.
 
-```sh
-$ npm install tslint -D
+But if you have no configuration yet and need more customization, install TSLint first:
+
+```shell
+$ npm install tslint --save-dev
 ```
 
-If you need customization, use the standard TSLint config file. Create a `tslint.json` file in the root directory of your repository.
+Next, create the configuration file (`tslint.json`):
+
+```shell
+$ npx tslint --init
+```
+
+Then, edit the configuration file as you want. For more details about the configuration, please see [the TSLint documentation](https://palantir.github.io/tslint/usage/configuration).
+
+## Default Configuration
+
+Sider prepares the following configuration by default. Sider uses the configuration when you have no configurations.
+
+```json
+{
+  "defaultSeverity": "error",
+  "extends": ["tslint:recommended"],
+  "jsRules": {},
+  "rules": {},
+  "rulesDirectory": []
+}
+```
 
 ## Configuration via `sider.yml`
 
-Here is an example setting for TSLint under `tslint`:
+Here are an example settings for TSLint:
 
 ```yaml
 linter:
   tslint:
-    npm_install: true
-    config: 'lint_yml/tslint.json'
-    exclude: 'node_modules/**'
-    project: 'tsconfig.json'
-    rules-dir: 'your_custom_rule'
-    glob: '**/*.ts{,x}'
+    config: my_tslint.json
+    exclude: "vendor/**"
+    project: frontend/tsconfig.json
+    rules-dir: your_custom_rules/
+    glob: "path/to/**/*.ts"
 ```
 
-### Options
+You can use the following options to make analysis fitter for your project.
 
-You can use several options to make analysis fitter for your project.
+| Name                        | Type                      | Default           | Description                                                                        |
+| --------------------------- | ------------------------- | ----------------- | ---------------------------------------------------------------------------------- |
+| `npm_install`               | -                         | -                 | See [here](../../getting-started/custom-configuration.md#npm_install-option).      |
+| [`config`](#config)         | `string`                  | -                 | [`--config`](https://palantir.github.io/tslint/usage/cli) option of TSLint.        |
+| [`exclude`](#exclude)       | `string`, `array<string>` | `node_modules/**` | [`--exclude`](https://palantir.github.io/tslint/usage/cli) option of TSLint.       |
+| [`project`](#project)       | `string`                  | -                 | [`--project`](https://palantir.github.io/tslint/usage/cli) option of TSLint.       |
+| [`rules-dir`](#rules-dir)   | `string`, `array<string>` | -                 | [`--rules-dir`](https://palantir.github.io/tslint/usage/cli) option of TSLint.     |
+| [`glob`](#glob)             | `string`                  | `**/*.ts{,x}`     | A glob pattern to analyze.                                                         |
+| [`type-check`](#type-check) | `boolean`                 | `false`           | **[DEPRECATED]** If you use TSLint 5.8.0+ and set `true`, your analysis will fail. |
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [`npm_install`](#npm_install) | `boolean`,<br />`string` | Resolve dependencies when analyzing with `npm`. |
-| [`config`](#config) | `string` | Set configuration file for TSLint. |
-| [`exclude`](#exclude) | `string`,<br />`array<string>`| Specify file and/or directory patterns to exclude from analysis. |
-| [`project`](#project) | `string` | Set your TypeScript project file; `tsconfig.json`. |
-| [`rules-dir`](#rules-dir) | `string`, <br />`array<string>` | Specify a directory which is custom rules that TSLint inspects. |
-| [`type-check`](#type-check) | `boolean` | [Deprecate] If you use TSLint 5.8.0+ and set `true`, Sider's analysis will be failed. |
-| [`glob`](#glob) | `string` | Specify glob patterns to analyze. |
+For details of the options, check the following sections.
 
-For details of the options, check following items.
+### `config`
 
-#### `npm_install`
+This option allows you to specify your configuration file except for the default one.
 
-This option controls `npm` command invocation. By using this option, you can install dependencies to your program.
+### `exclude`
 
-| Value | Execution Command |
-| :---- | :---------------- |
-| `true` | `npm install --ignore-scripts` |
-| `false` | None |
-| `development` | `npm install --only=development --ignore-scripts` |
-| `production` | `npm install --only=production --ignore-scripts` |
-| Other values | Sider analysis fails. |
-
-If your `package.json` contains a dependency which cannot be installed in the Sider container, `npm install` fails. The analysis will continue but the results may be inaccurate. In this case, try using the `development` or `production` options, or use the `optionalDependency` setting.
-
-#### `config`
-
-This option controls which configuration file TSLint uses. If you have a `tslint.json` file, use this option.
-
-#### `exclude`
-
-This option controls which files TSLint excludes from linting. The default value is `node_modules/**`.
-
-If you want to exclude multiple files/directories, declare them as a sequence:
+This option allows you to exclude files from analysis. A glob pattern is available also. If you want to exclude multiple files or directories, declare them as a sequence as follows:
 
 ```yaml
 linter:
   tslint:
     exclude:
-      - 'node_modules/**'
-      - '.git/**'
-      - 'cache/**'
+      - "node_modules/**"
+      - "cache/**"
 ```
 
-#### `project`
+### `project`
 
-This option controls project file. If you have `tsconfig.json` file, declare it in this directive.
+This option allows you to specify a TypeScript project file or directory.
 
-#### `rules-dir`
+### `rules-dir`
 
-This option controls customized rules that TSLint inspects.
-
-If you want to set multiple custom rules, declare them as follow:
+This option allows you to specify your own rules. If you want to use multiple rules, declare them as follows:
 
 ```yaml
 linter:
@@ -103,14 +104,14 @@ linter:
       - rules/AnotherCustomRule
 ```
 
-Note that you need to use TSLint after version 5.12.0 to set `rules-dir` option as an array.
+> Note that you need to use TSLint since version **5.12.0** to set the `rules-dir` option as an array.
 
-#### `type-check`
+### `glob`
+
+This option allows you to specify files to analyze.
+
+### `type-check`
 
 This option controls whether to enable type checking when running TSLint. If you want type checking, set this to `true`.
 
-The option is deprecated in version 5.8.0 of TSLint. TSLint no longer does type checking. If you would like to know about the change, see [https://github.com/palantir/tslint/pull/3322](https://github.com/palantir/tslint/pull/3322).
-
-#### `glob`
-
-This option controls files that TSLint inspects. By default, `.ts` and `.tsx` files are inspected.
+> Note that the option is **deprecated** since TSLint version **5.8.0**. TSLint no longer have done type checking since it. For more details about the change, see [the pull request](https://github.com/palantir/tslint/pull/3322).

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -45,6 +45,14 @@
       },
       {
         "type": "subcategory",
+        "label": "CSS",
+        "ids": [
+          "tools/css/stylelint",
+          "tools/css/scss-lint"
+        ]
+      },
+      {
+        "type": "subcategory",
         "label": "PHP",
         "ids": [
           "tools/php/phinder",
@@ -64,14 +72,6 @@
         "label": "Swift",
         "ids": [
           "tools/swift/swiftlint"
-        ]
-      },
-      {
-        "type": "subcategory",
-        "label": "CSS",
-        "ids": [
-          "tools/css/stylelint",
-          "tools/css/scss-lint"
         ]
       },
       {


### PR DESCRIPTION
Especially for [the release on August 20](https://blog.sideci.com/new-release-about-yarn-support-40123d5f9d84).

## Summary

- Shallow heading levels for each option of analyzers. Deeper levels make it difficult for us to understand a document structure rapidly.
- Simplify some verbose description, and add some links to the official documentation of analyzers.
- Format markdown files in this PR via **Prettier**, so this PR has many diffs.
- Move the CSS category right next to the JavaScript category. They are relevant to each other.