### PR TITLE
Update tools' default versions and language versions

### DIFF
--- a/docs/tools/css/stylelint.md
+++ b/docs/tools/css/stylelint.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # stylelint
 
-| Supported Version          | Language                    | Runtime        | Website              |
-| -------------------------- | --------------------------- | -------------- | -------------------- |
-| 8.3.0+ (default to 10.1.0) | CSS and flavors (e.g. Sass) | Node.js 12.10.0 | https://stylelint.io |
+| Supported Version          | Language                    | Runtime         | Website              |
+| -------------------------- | --------------------------- | --------------- | -------------------- |
+| 8.3.0+ (default to 11.0.0) | CSS and flavors (e.g. Sass) | Node.js 12.10.0 | https://stylelint.io |
 
 ## Getting Started
 

--- a/docs/tools/go/golint.md
+++ b/docs/tools/go/golint.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # Golint
 
-| Language | Website |
-| -------- | -------- |
-| Go 1.12.7 | [https://github.com/golang/lint](https://github.com/golang/lint) |
+| Language  | Website                        |
+| --------- | ------------------------------ |
+| Go 1.13.1 | https://github.com/golang/lint |
 
 ## Getting Started
 
@@ -18,4 +18,3 @@ To start using Golint, enable Golint in repository setting.
 ## Configuration
 
 There is no configuration available.
-

--- a/docs/tools/go/gometalinter.md
+++ b/docs/tools/go/gometalinter.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # Go Meta Linter
 
-| Supported Version | Language | Website |
-| ----------------- | -------- | -------- |
-| 2.0.11 | Go 1.12.7 | https://github.com/alecthomas/gometalinter |
+| Supported Version | Language  | Website                                    |
+| ----------------- | --------- | ------------------------------------------ |
+| 2.0.11            | Go 1.13.1 | https://github.com/alecthomas/gometalinter |
 
 > **DEPRECATED**: Sider will no longer support Go Meta Linter because Go Meta Linter has been archived since April 7, 2019.
 > For more details, see the [readme](https://github.com/alecthomas/gometalinter#readme).
@@ -26,8 +26,7 @@ Sider tries to download dependencies if your project contains `glide.yaml`. This
 
 If `glide.yaml` contains a dependency to a library in a private repository, please add the SSH key necessary to clone it.
 
-* [Use other private repositories for analysis](../../advanced-settings/private-dependencies.md)
-
+- [Use other private repositories for analysis](../../advanced-settings/private-dependencies.md)
 
 > Note that need to set `import_path` option in `sider.yml` when you would like to run `glide install` on analysis.
 > See [here](#import_path) for details.
@@ -68,13 +67,13 @@ linter:
     import_path: github.com/your-org-name/your-repo-name
     options:
       config: config/settings.json
-      exclude: 'REGEXP'
-      include: 'REGEXP'
+      exclude: "REGEXP"
+      include: "REGEXP"
       skip: vendor/github.com/
       cyclo-over: 10
       min-confidence: .80
       dupl-threshold: 50
-      severity: 'error'
+      severity: "error"
       vendor: true
       tests: true
       errors: true
@@ -141,19 +140,19 @@ This option allows you to manage whether to show only errors.
 
 This option allows you to manage whether to run only fast linters. If you declare true in this option, the following faster linters willl run:
 
-* dupl
-* gosec
-* goconst
-* gocyclo
-* gofmt
-* goimports
-* golint
-* gotype
-* ineffassign
-* lll
-* misspell
-* vet
-* vetshadow
+- dupl
+- gosec
+- goconst
+- gocyclo
+- gofmt
+- goimports
+- golint
+- gotype
+- ineffassign
+- lll
+- misspell
+- vet
+- vetshadow
 
 #### `disable-all`
 
@@ -166,4 +165,3 @@ This option allows you to enable linters previously disabled. Set linters as a l
 #### `disable`
 
 This option allows you to disable linters previously enabled. Set linters as a lint in this option.
-

--- a/docs/tools/go/govet.md
+++ b/docs/tools/go/govet.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # go vet
 
-| Language | Website |
-| -------- | -------- |
-| Go 1.12.7 | [https://golang.org/cmd/vet/](https://golang.org/cmd/vet/) |
+| Language  | Website                    |
+| --------- | -------------------------- |
+| Go 1.13.1 | https://golang.org/cmd/vet |
 
 ## Getting Started
 
@@ -18,4 +18,3 @@ To start using go vet, enable it in repository setting.
 ## Configuration
 
 There is no configuration available.
-

--- a/docs/tools/java/checkstyle.md
+++ b/docs/tools/java/checkstyle.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # Checkstyle
 
-| Supported Version | Language | Website |
-| ----------------- | -------- | -------- |
-| 8.23 | Java 12.0.1 | [http://checkstyle.sourceforge.net/](http://checkstyle.sourceforge.net/) |
+| Supported Version | Language    | Website                           |
+| ----------------- | ----------- | --------------------------------- |
+| 8.25              | Java 12.0.1 | http://checkstyle.sourceforge.net |
 
 ## Getting Started
 
@@ -17,7 +17,7 @@ To start using Checkstyle, enable it in [Repository Settings](../../getting-star
 
 ## Configuration
 
-You can customize Checkstyle analysis using `sider.yml`.
+You can customize Checkstyle analysis using `sider.yml`. For example:
 
 ```yaml
 linter:
@@ -27,48 +27,53 @@ linter:
     exclude:
       - vendor
       - pattern: foo
+      - string: foo
     ignore:
       - warning
       - info
+    properties: checkstyle.properties
 ```
+
+| Name                        | Type                                       | Default  | Description                        |
+| --------------------------- | ------------------------------------------ | -------- | ---------------------------------- |
+| [`config`](#config)         | `string`                                   | `google` | Coding standard name or file path. |
+| [`dir`](#dir)               | `string`, `array<string>`                  | `.`      | Directory to analyze.              |
+| [`exclude`](#exclude)       | `string`, `array<string>`, `array<object>` | -        | Excluded directory.                |
+| [`ignore`](#ignore)         | `array<string>`                            | -        | Ignored severities.                |
+| [`properties`](#properties) | `string`                                   | -        | Properties file.                   |
 
 ### `config`
 
-This option allows you to declare the coding standard you want to follow. The default value is `google`.
+This option allows you to declare the coding standard you want to follow.
 
 Supported values are:
 
-* `google` \(for `/google_checks.xml`\)
-* `sun` \(for `/sun_checks.xml`\)
-* Path to your configuration file
+- [`google`](https://checkstyle.sourceforge.io/google_style.html) (for `/google_checks.xml`)
+- [`sun`](https://checkstyle.sourceforge.io/sun_style.html) (for `/sun_checks.xml`)
+- Path to your configuration file
 
 When you write `google` or `sun`, config files distributed from Checkstyle are used.
 
 ### `dir`
 
-This option allows you to specify the directories you want to check in your repository. The default value is `.`.
-
-You can write a string or a sequence of strings.
+This option allows you to specify the directories you want to check in your repository.
 
 ### `exclude`
 
 This option allows you to specify `-e` and `-x` command line options passed to the `checkstyle` command.
 
-* If `exclude` is a string, the `-e` option will be used.
-* If it's an object with a `string` key, \(`{ string: vendor }`\), the `-e` option will be used.
-* If it's as object with a `pattern` key, \(`{ pattern: vendor }`\), the `-x` option will be used.
+- If `exclude` is a string, the `-e` option will be used.
+- If including object(s) with a `string` key (e.g. `{ string: vendor }`), the `-e` option will be used.
+- If including object(s) with a `pattern` key (e.g. `{ pattern: vendor }`), the `-x` option will be used.
 
-The default value is empty \(nothing will be excluded\).
+By default, nothing will be excluded.
 
 ### `ignore`
 
 This option allows you to ignore issues based on their severity. Write the list of severities you want to ignore.
 
-The default value is empty \(nothing will be ignored\).
+By default, nothing will be ignored.
 
 ### `properties`
 
 This option allows you to specify the properties file passed to `checkstyle`. The value will be passed to Checkstyle's `-p` option.
-
-There is no default value.
-

--- a/docs/tools/java/pmd.md
+++ b/docs/tools/java/pmd.md
@@ -9,7 +9,7 @@ hide_title: true
 
 | Supported Version | Language    | Website               |
 | ----------------- | ----------- | --------------------- |
-| 6.17.0            | Java 12.0.1 | https://pmd.github.io |
+| 6.18.0            | Java 12.0.1 | https://pmd.github.io |
 
 ## Getting Started
 
@@ -51,6 +51,7 @@ The default value contains the 4 rulesets below:
 - [`category/java/errorprone.xml`](https://github.com/pmd/pmd/blob/master/docs/pages/pmd/rules/java/errorprone.md)
 - [`category/java/multithreading.xml`](https://github.com/pmd/pmd/blob/master/docs/pages/pmd/rules/java/multithreading.md)
 - [`category/java/performance.xml`](https://github.com/pmd/pmd/blob/master/docs/pages/pmd/rules/java/performance.md)
+- [`category/java/security.xml`](https://github.com/pmd/pmd/blob/master/docs/pages/pmd/rules/java/security.md)
 
 You can also specify the rulesets file in your repository.
 

--- a/docs/tools/javascript/eslint.md
+++ b/docs/tools/javascript/eslint.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # ESLint
 
-| Supported Version           | Language   | Runtime        | Website            |
-| --------------------------- | ---------- | -------------- | ------------------ |
-| 3.19.0+ (default to 5.16.0) | JavaScript | Node.js 12.10.0 | https://eslint.org |
+| Supported Version          | Language   | Runtime         | Website            |
+| -------------------------- | ---------- | --------------- | ------------------ |
+| 3.19.0+ (default to 6.5.1) | JavaScript | Node.js 12.10.0 | https://eslint.org |
 
 ## Getting Started
 

--- a/docs/tools/javascript/tslint.md
+++ b/docs/tools/javascript/tslint.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # TSLint
 
-| Supported Version          | Language   | Runtime        | Website                           |
-| -------------------------- | ---------- | -------------- | --------------------------------- |
-| 5.0.0+ (default to 5.18.0) | TypeScript | Node.js 12.10.0 | https://palantir.github.io/tslint |
+| Supported Version          | Language   | Runtime         | Website                           |
+| -------------------------- | ---------- | --------------- | --------------------------------- |
+| 5.0.0+ (default to 5.20.0) | TypeScript | Node.js 12.10.0 | https://palantir.github.io/tslint |
 
 ## Getting Started
 

--- a/docs/tools/javascript/tyscan.md
+++ b/docs/tools/javascript/tyscan.md
@@ -9,7 +9,7 @@ hide_title: true
 
 | Supported Version         | Language   | Runtime         | Website                         |
 | ------------------------- | ---------- | --------------- | ------------------------------- |
-| 0.2.1+ (default to 0.2.1) | TypeScript | Node.js 12.10.0 | https://github.com/sider/tyscan |
+| 0.2.1+ (default to 0.3.1) | TypeScript | Node.js 12.10.0 | https://github.com/sider/tyscan |
 
 ## Getting Started
 

--- a/docs/tools/php/codesniffer.md
+++ b/docs/tools/php/codesniffer.md
@@ -7,13 +7,13 @@ hide_title: true
 
 # PHP_CodeSniffer
 
-| Supported Version | Language | Website |
-| ----------------- | -------- | -------- |
-| 3.4.2 | PHP 7.3.9 | [https://pear.php.net/package/PHP\_CodeSniffer](https://pear.php.net/package/PHP_CodeSniffer) |
+| Supported Version | Language   | Website                                      |
+| ----------------- | ---------- | -------------------------------------------- |
+| 3.4.2             | PHP 7.3.10 | https://pear.php.net/package/PHP_CodeSniffer |
 
 ## Getting Started
 
-To start using PHP\_CodeSniffer, enable it in [Repository Settings](../../getting-started/repository-settings.md). To configure the coding standard you want to follow, add `sider.yml` in your repository and set the `standard` option:
+To start using PHP_CodeSniffer, enable it in [Repository Settings](../../getting-started/repository-settings.md). To configure the coding standard you want to follow, add `sider.yml` in your repository and set the `standard` option:
 
 ```yaml
 linter:
@@ -33,14 +33,14 @@ Sider tries to detect the most suitable standard and target directory for your p
 
 The following standards are detected automatically:
 
-* `CakePHP`
-* `Symfony`
+- `CakePHP`
+- `Symfony`
 
 Autodetection is based on file names and directory structure. If autodetection fails, you can specify a standard in `sider.yml`.
 
 ## Configuration via `sider.yml`
 
-Example setting for PHP\_CodeSniffer under `code_sniffer`:
+Example setting for PHP_CodeSniffer under `code_sniffer`:
 
 ```yaml
 linter:
@@ -52,37 +52,35 @@ linter:
     ignore: app/Vendor
 ```
 
-### Options
+You can use several options to fine-tune PHP_CodeSniffer to your project:
 
-You can use several options to fine-tune PHP\_CodeSniffer to your project:
+| Name                        | Type                | Description                                             |
+| --------------------------- | ------------------- | ------------------------------------------------------- |
+| [`version`](#version)       | `string`, `integer` | Declare PHP_CodeSniffer version explicitly.             |
+| [`dir`](#dir)               | `string`            | Set targets to analyze.                                 |
+| [`standard`](#standard)     | `string`            | Set coding standard or your config file when analyzing. |
+| [`extensions`](#extensions) | `string`            | Set extensions to analyze.                              |
+| [`encoding`](#encoding)     | `string`            | Set file encoding.                                      |
+| [`ignore`](#ignore)         | `string`            | Excludes files or directories from analysis.            |
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [`version`](#version) | `string`,<br />`integer` | Declare PHP\_CodeSniffer version explicitly. |
-| [`dir`](#dir) | `string` | Set targets to analyze. |
-| [`standard`](#standard) | `string` | Set coding standard or your config file when analyzing. |
-| [`extensions`](#extensions) | `string` | Set extensions to analyze. |
-| [`encoding`](#encoding) | `string` | Set file encoding. |
-| [`ignore`](#ignore) | `string` | Excludes files or directories from analysis. |
+### `version`
 
-#### `version`
+This option controls which major version of PHP_CodeSniffer is used. The default value is `3`.
+Sider has stopped supporting v2 of PHP_CodeSniffer. Therfore, if you set `2` in this option, Sider will execute v3.
 
-This option controls which major version of PHP\_CodeSniffer is used. The default value is `3`.
-Sider has stopped supporting v2 of PHP\_CodeSniffer. Therfore, if you set `2` in this option, Sider will execute v3.
+### `dir`
 
-#### `dir`
-
-This option controls directories Sider inspects. The default value is dependent on the frameworks PHP\_CodeSniffer supports. If you are not using any frameworks or are using a framework PHP\_CodeSniffer does not support, `./` is used.
+This option controls directories Sider inspects. The default value is dependent on the frameworks PHP_CodeSniffer supports. If you are not using any frameworks or are using a framework PHP_CodeSniffer does not support, `./` is used.
 
 If you would like to exclude specific directories, you can specify them in a custom ruleset file.
 
-#### `standard`
+### `standard`
 
 This option controls coding standard of your project. If you leave this value empty, Sider tries to detect the standard automatically.
 
 `PSR2` is used when auto detection fails.
 
-You can use any standards the PHP\_CodeSniffer supports:
+You can use any standards the PHP_CodeSniffer supports:
 
 ```bash
 $ phpcs3 -i
@@ -91,14 +89,14 @@ The installed coding standards are MySource, PEAR, PSR1, PSR2, Squiz, Zend, Symf
 
 You can also define your own standard, and enter the path to the config file here.
 
-#### `extensions`
+### `extensions`
 
 This option controls extensions of files Sider inspects. The default value is `php`.
 
-#### `encoding`
+### `encoding`
 
 This option controls file encoding.
 
-#### `ignore`
+### `ignore`
 
 A comma-separated list of patterns to ignore files and directories by.

--- a/docs/tools/php/phinder.md
+++ b/docs/tools/php/phinder.md
@@ -7,21 +7,20 @@ hide_title: true
 
 # Phinder
 
-| Supported Version | Language | Website |
-| ----------------- | -------- | -------- |
-| 0.9.2 | PHP 7.3.9 | [https://github.com/sider/phinder](https://github.com/sider/phinder) |
+| Supported Version | Language   | Website                          |
+| ----------------- | ---------- | -------------------------------- |
+| 0.9.2             | PHP 7.3.10 | https://github.com/sider/phinder |
 
 ## Getting Started
 
-To start using Phinder, enable it in [Repository Settings](../../getting-started/repository-settings.md) and put a `phinder.yml` config file in your repository. Visit the project page on GitHub to see a sample `phinder.yml`:
-
-* [Phinder sample](https://github.com/sider/phinder/tree/master/sample)
+To start using Phinder, enable it in [Repository Settings](../../getting-started/repository-settings.md) and put a `phinder.yml` config file in your repository.
+Visit the project page on GitHub to see a [sample `phinder.yml`](https://github.com/sider/phinder/blob/master/sample/phinder.yml):
 
 <div class="Video">
- <iframe class="Video__iframe" src="https://www.youtube.com/embed/ErHtinxR3ns" frameborder="0" allowfullscreen></iframe>
+  <iframe class="Video__iframe" src="https://www.youtube.com/embed/ErHtinxR3ns" frameborder="0" allowfullscreen></iframe>
 </div>
 
-## Sample Configuration
+## Configuration
 
 Here's a sample Phinder configuration in `sider.yml`:
 
@@ -32,12 +31,10 @@ linter:
     php: src
 ```
 
-## Options
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
+| Name            | Type     | Description                                                    |
+| --------------- | -------- | -------------------------------------------------------------- |
 | [`rule`](#rule) | `string` | Specify your configuration file or directory name for Phinder. |
-| [`php`](#php) | `string` | Specify file name or directory name to analyze. |
+| [`php`](#php)   | `string` | Specify file name or directory name to analyze.                |
 
 ### `rule`
 
@@ -58,4 +55,4 @@ This option allows you to specify the path of your project to analyze. If this i
 linter:
   phinder:
     php: src # Phinder will analyze '.php' files in '/src' directory.
- ```
+```

--- a/docs/tools/php/phpmd.md
+++ b/docs/tools/php/phpmd.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # PHPMD
 
-| Supported Version | Language | Website |
-| ----------------- | -------- | -------- |
-| 2.6.1 | PHP 7.3.9 | [https://phpmd.org/](https://phpmd.org/) |
+| Supported Version | Language   | Website           |
+| ----------------- | ---------- | ----------------- |
+| 2.6.1             | PHP 7.3.10 | https://phpmd.org |
 
 ## Getting Started
 
@@ -95,35 +95,33 @@ linter:
     strict: true
 ```
 
-### Options
-
 You can use several options to fine-tune PHPMD to your project:
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [`target`](#target) | `array<string>` | Set target files or directories to analyze. |
-| [`rule`](#rule) | `string` | Specify coding rules or your own rule set file. |
-| [`minimumpriority`](#minimumpriority) | `integer` | Set the priority threshold which PHPMD ignores.  |
-| [`suffixes`](#suffixes) | `string` | Set extensions of filenames for analysis. |
-| [`exclude`](#exclude) | `string` | Set files or directories to exclude from analysis. |
-| [`strict`](#strict) | `boolean` | If `true`, PHPMD will report `@SuppressWarnings` nodes. |
+| Name                                  | Type            | Description                                             |
+| ------------------------------------- | --------------- | ------------------------------------------------------- |
+| [`target`](#target)                   | `array<string>` | Set target files or directories to analyze.             |
+| [`rule`](#rule)                       | `string`        | Specify coding rules or your own rule set file.         |
+| [`minimumpriority`](#minimumpriority) | `integer`       | Set the priority threshold which PHPMD ignores.         |
+| [`suffixes`](#suffixes)               | `string`        | Set extensions of filenames for analysis.               |
+| [`exclude`](#exclude)                 | `string`        | Set files or directories to exclude from analysis.      |
+| [`strict`](#strict)                   | `boolean`       | If `true`, PHPMD will report `@SuppressWarnings` nodes. |
 
-#### `target`
+### `target`
 
 This option controls target paths to inspect. This is an optional setting that you do not need to specify if you don't have any performance issues.
 
-#### `rule`
+### `rule`
 
 This option controls `--rule` command line option that is passed to `phpmd`. You can specify a comma-separated list of rule names, or an array of rule names.
 
 The valid rule names are:
 
-* `cleancode`
-* `codesize`
-* `controversial`
-* `design`
-* `naming`
-* `unusedcode`
+- `cleancode`
+- `codesize`
+- `controversial`
+- `design`
+- `naming`
+- `unusedcode`
 
 You can also specify a rule set file name:
 
@@ -135,19 +133,18 @@ linter:
 
 For more information about PHPMD rulesets, see [PHPMD - PHP Mess Detector: Documentation\#Rules](https://phpmd.org/rules/index.html).
 
-#### `minimumpriority`
+### `minimumpriority`
 
 This option controls the rule priority threshold. Rules below the priority you declare will be ignored.
 
-#### `suffixes`
+### `suffixes`
 
 This option controls valid filename extensions. Use a comma-separated list to inspect multiple file extensions, e.g. `php,phtml`.
 
-#### `exclude`
+### `exclude`
 
 This option controls directories to exclude from analysis objects. Use a comma-separated list to ignore multiple directories, e.g. `app/logs/,web/bundles/`.
 
-#### `strict`
+### `strict`
 
 This option controls whether to report nodes that have the `@SuppressWarnings` annotation. The default is `false`. To learn more about `@SuppressWarnings`, see [PHPMD Suppressing Warnings](https://phpmd.org/documentation/suppress-warnings.html).
-

--- a/docs/tools/python/flake8.md
+++ b/docs/tools/python/flake8.md
@@ -9,7 +9,7 @@ hide_title: true
 
 | Supported Version | Language | Website |
 | ----------------- | -------- | -------- |
-| 3.7.7 | Python 2.7.16, 3.7.4 | [http://flake8.pycqa.org/en/latest/](http://flake8.pycqa.org/en/latest/) |
+| 3.7.8 | Python 2.7.16, 3.7.4 | http://flake8.pycqa.org |
 
 ## Getting Started
 

--- a/docs/tools/ruby/haml-lint.md
+++ b/docs/tools/ruby/haml-lint.md
@@ -9,7 +9,7 @@ hide_title: true
 
 | Version Constraints | Language | Website |
 | ----------------- | -------- | -------- |
-| 0.26.0+ (default to 0.32.0) | [HAML](http://haml.info) (Ruby 2.6.4) | https://github.com/sds/haml-lint |
+| 0.26.0+ (default to 0.33.0) | [HAML](http://haml.info) (Ruby 2.6.4) | https://github.com/sds/haml-lint |
 
 ## Configuration via `sider.yml`
 

--- a/docs/tools/ruby/rubocop.md
+++ b/docs/tools/ruby/rubocop.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # RuboCop
 
-| Version Constraints | Language | Website |
-| ----------------- | -------- | -------- |
-| 0.35.0+ (default to 0.74.0) | Ruby 2.5.6 | https://docs.rubocop.org |
+| Version Constraints         | Language   | Website                  |
+| --------------------------- | ---------- | ------------------------ |
+| 0.35.0+ (default to 0.75.0) | Ruby 2.5.6 | https://docs.rubocop.org |
 
 ## Configuration via `sider.yml`
 
@@ -27,13 +27,13 @@ linter:
 
 ### Options
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| [`root_dir`](../../getting-started/custom-configuration.md#root_dir-option) | `string` | Directory in which the analyzer runs. |
-| [`gems`](../../getting-started/custom-configuration.md#gems-option) | `array<string, object>` | Definition of gems to be installed. |
-| `config` | `string` | A file path passed as `--config` option. |
-| [`rails`](#rails) | `boolean` | Add `--rails` flag. |
-| [`safe`](#safe) | `boolean` | Add `--safe` flag. Default: `false` |
+| Name                                                                        | Type                    | Description                              |
+| --------------------------------------------------------------------------- | ----------------------- | ---------------------------------------- |
+| [`root_dir`](../../getting-started/custom-configuration.md#root_dir-option) | `string`                | Directory in which the analyzer runs.    |
+| [`gems`](../../getting-started/custom-configuration.md#gems-option)         | `array<string, object>` | Definition of gems to be installed.      |
+| `config`                                                                    | `string`                | A file path passed as `--config` option. |
+| [`rails`](#rails)                                                           | `boolean`               | Add `--rails` flag.                      |
+| [`safe`](#safe)                                                             | `boolean`               | Add `--safe` flag. Default: `false`      |
 
 #### `rails`
 


### PR DESCRIPTION
## Changes

- Language
  - Go: 1.12.7 -> 1.13.1
  - PHP: 7.3.9 -> 7.3.10
- Tool
  - Checkstyle: 8.23 -> 8.25
  - ESLint: 5.16.0 -> 6.5.1
  - Flake8: 3.7.7 -> 3.7.8
  - HAML-Lint: 0.32.0 -> 0.33.0
  - PMD Java: 6.17.0 -> 6.18.0
  - RuboCop: 0.74.0 -> 0.75.0
  - stylelint: 10.1.0 -> 11.0.0
  - TSLint: 5.18.0 -> 5.20.0
  - TyScan: 0.2.1 -> 0.3.1

## See also

- https://github.com/sider/runners/blob/master/CHANGELOG.md#040
- https://github.com/sider/devon_rex/blob/master/CHANGELOG.md#230

## To-do

- [x] Merge this PR when the new runners will be shipped.