### PR TITLE
Drop Sass and Ruby versions on SCSS-Lint page

### DIFF
--- a/docs/tools/css/scss-lint.md
+++ b/docs/tools/css/scss-lint.md
@@ -9,7 +9,7 @@ hide_title: true
 
 | Supported Version | Language | Website |
 | ----------------- | -------- | -------- |
-| 0.57.1 | Sass 3.6.0 / Ruby 2.5.5| https://github.com/sds/scss-lint |
+| 0.57.1 | [Sass](https://sass-lang.com) | https://github.com/sds/scss-lint |
 
 > **DEPRECATED**: Sider will no longer support SCSS-Lint because SCSS-Lint will stop its maintenance. We recommend [stylelint](https://stylelint.io) and [stylelint-scss](https://github.com/kristerkari/stylelint-scss) as an alternative.
 > For more details, see the [announce](https://github.com/sds/scss-lint#notice-consider-other-tools-before-adopting-scss-lint).


### PR DESCRIPTION
These versions are not very important and hard to maintain.