### PR TITLE
Fix ShellCheck configuration example

### DIFF
--- a/docs/tools/shellscript/shellcheck.md
+++ b/docs/tools/shellscript/shellcheck.md
@@ -28,7 +28,7 @@ Here is a configuration example via [`sider.yml`](../../getting-started/custom-c
 ```yaml
 linter:
   shellcheck:
-    target: "src"
+    target: "src/**/*.{sh,bash}"
     include: "SC2104,SC2105"
     exclude: "SC1000,SC1118"
     enable: "all"


### PR DESCRIPTION
The `target` option can receive only files (not directories).