### PR TITLE
Add a description about X-Forwarded-For HTTP header

### DIFF
--- a/docs/enterprise/healthcheck.md
+++ b/docs/enterprise/healthcheck.md
@@ -6,6 +6,8 @@ sidebar_label: Health Check Guide
 
 When you want to use load balancers for Sider Enterprise, you may need to configure _health checks_. Sider components provide health check endpoints to make sure the web containers are running normally.
 
+Note that your load balancer must set the `X-Forwarded-For` HTTP header for Sider components.
+
 ## Health checking sideci
 
 `sideci_web` container provides `/api/health_check` endpoint for health checks. It always returns a `200` response, so that you can test if the component is up and receiving HTTP requests.


### PR DESCRIPTION
For Sider Enterprise, users sometimes have to configure the load balancer to set the `X-Forwarded-For` HTTP header.