### PR TITLE
Add deprecated mark on Flake8 page

### DIFF
--- a/docs/tools/python/flake8.md
+++ b/docs/tools/python/flake8.md
@@ -11,6 +11,8 @@ hide_title: true
 | ----------------- | -------------------- | ----------------------- |
 | 3.7.9             | Python 2.7.16, 3.7.4 | http://flake8.pycqa.org |
 
+> **DEPRECATED**: Sider will drop the support of Python 2. So, the `version` option of `sider.yml` and the detection of Python version via `.python-version` features are going to be unavailable near the future.
+
 ## Getting Started
 
 To start using Flake8, enable it in [Repository Settings](../../getting-started/repository-settings.md).
@@ -67,9 +69,9 @@ linter:
 You can use several options to fine-tune Flake8 to your project.
 
 | Name                                                                        | Type                 | Default | Description                                                            |
-| --------------------------------------------------------------------------- | -------------------- | ------- | ---------------------------------------------------------------------- |
+| :-------------------------------------------------------------------------- | :------------------- | :------ | :--------------------------------------------------------------------- |
 | [`root_dir`](../../getting-started/custom-configuration.md#root_dir-option) | `string`             | -       | A root directory.                                                      |
-| [`version`](#version)                                                       | `integer`            | `3`     | Specify Python version.                                                |
+| [`version`](#version)                                                       | `integer`            | `3`     | **[DEPRECATED]** Specify Python version.                               |
 | [`plugins`](#plugins)                                                       | `string`, `string[]` | -       | Set Flake8 plugins. It also allows to specify these plugins' versions. |
 
 ### `version`


### PR DESCRIPTION
Python 2 will be retired soon.

https://www.python.org/psf/press-release/pr20191220/