### PR TITLE
Fix wrong `sider.yml` sample for PHP_CodeSniffer

### DIFF
--- a/docs/tools/php/codesniffer.md
+++ b/docs/tools/php/codesniffer.md
@@ -19,8 +19,7 @@ To start using PHP_CodeSniffer, enable it in [Repository Settings](../../getting
 linter:
   code_sniffer:
     dir: app/
-    options:
-      standard: CakePHP
+    standard: CakePHP
 ```
 
 ## Default Configuration


### PR DESCRIPTION
`options` is deprecated.