### PR TITLE
[News] Update the default version of RuboCop to 0.80.0

### DIFF
--- a/docs/news/2020.md
+++ b/docs/news/2020.md
@@ -9,6 +9,17 @@ hide_title: true
 
 This document describes notable changes on Sider in the year 2020.
 
+## Update the default version of RuboCop to 0.80.0
+
+<time class="news-date" datetime="2020-02-19">February 19, 2020</time>
+
+Yesterday, [RuboCop 0.80.0](https://github.com/rubocop-hq/rubocop/releases/tag/v0.80.0) has been released!
+This release includes some breaking changes, so today we have updated our default version of RuboCop.
+
+This does not affect repositories that use their own version of RuboCop defined in `Gemfile.lock` or `sider.yml`.
+
+See also our [RuboCop document](../tools/ruby/rubocop.md).
+
 ## Update languages and tools on Feb 13, 2020
 
 <time class="news-date" datetime="2020-02-13">February 13, 2020</time>

--- a/docs/tools/ruby/rubocop.md
+++ b/docs/tools/ruby/rubocop.md
@@ -9,7 +9,7 @@ hide_title: true
 
 | Supported Version           | Language   | Website                  |
 | --------------------------- | ---------- | ------------------------ |
-| 0.61.0+ (default to 0.79.0) | Ruby 2.6.5 | https://docs.rubocop.org |
+| 0.61.0+ (default to 0.80.0) | Ruby 2.6.5 | https://docs.rubocop.org |
 
 ## Configuration via `sider.yml`
 


### PR DESCRIPTION
See <https://github.com/sider/runners/blob/master/CHANGELOG.md#0200>.