### PR TITLE
Change FxCop Analyzer homepage URL

### DIFF
--- a/docs/tools/csharp/fxcop.md
+++ b/docs/tools/csharp/fxcop.md
@@ -9,9 +9,9 @@ hide_title: true
 
 > This is **not published yet**.
 
-| Supported Version | Language | Website                                                                                                   |
-| :---------------- | :------- | :-------------------------------------------------------------------------------------------------------- |
-| 2.9.8             | C#       | [dotnet/roslyn-analyzers](https://github.com/dotnet/roslyn-analyzers#microsoftcodeanalysisfxcopanalyzers) |
+| Supported Version | Language | Website                                                                    |
+| :---------------- | :------- | :------------------------------------------------------------------------- |
+| 2.9.8             | C#       | https://docs.microsoft.com/en-us/visualstudio/code-quality/fxcop-analyzers |
 
 **FxCop** is a static analysis tool for [.NET platform](https://dotnet.microsoft.com/). It supports both of C# and Visual Basic .NET. However, Sider supports C# project only now.
 


### PR DESCRIPTION
Now, the URL is https://github.com/dotnet/roslyn-analyzers#microsoftcodeanalysisfxcopanalyzers. It may be broken because it is a pointer to README.md in a github repo.

This commit change the url to permanent one.