### PR TITLE
Improve documents for deprecations and betas

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,12 +26,9 @@ This section has documents about how to use Sider.
 
 ## Analysis Tools
 
-This section has documents about analysis tools which Sider supports. We have analysis options to fit your project. Sider supports 20+ tools for 8 languages.
+This section has documents about analysis tools which Sider supports. We have analysis options to fit your project. Sider supports 30+ tools for 10+ languages.
 
 ### Ruby
-
-<details open>
-  <summary>6 tools are available.</summary>
 
 - [RuboCop](./tools/ruby/rubocop.md)
 - [Reek](./tools/ruby/reek.md)
@@ -40,137 +37,72 @@ This section has documents about analysis tools which Sider supports. We have an
 - [Brakeman](./tools/ruby/brakeman.md)
 - [HAML-Lint](./tools/ruby/haml-lint.md)
 
-</details>
-
 ### Java
-
-<details open>
-  <summary>3 tools are available.</summary>
 
 - [Checkstyle](./tools/java/checkstyle.md)
 - [PMD](./tools/java/pmd.md)
 - [JavaSee](./tools/java/javasee.md)
-  </details>
 
 ### Kotlin
 
-<details open>
-  <summary>1 tool is available.</summary>
-
 - [ktlint](./tools/kotlin/ktlint.md)
 - [detekt](./tools/kotlin/detekt.md)
-  </details>
 
 ### JavaScript and Flavors
 
-<details open>
-  <summary>5 tools are available.</summary>
-
 - [ESLint](./tools/javascript/eslint.md)
 - [JSHint](./tools/javascript/jshint.md)
-- [TSLint](./tools/javascript/tslint.md)
 - [TyScan](./tools/javascript/tyscan.md)
 - [CoffeeLint](./tools/javascript/coffeelint.md)
-
-</details>
+- [TSLint](./tools/javascript/tslint.md)
 
 ### CSS
-
-<details open>
-  <summary>2 tools are available.</summary>
 
 - [stylelint](./tools/css/stylelint.md)
 - [SCSS-Lint](./tools/css/scss-lint.md)
 
-</details>
-
 ### PHP
 
-<details open>
-  <summary>3 tools are available.</summary>
-
-- [Phinder](./tools/php/phinder.md)
-- [PHPMD](./tools/php/phpmd.md)
 - [PHP_CodeSniffer](./tools/php/codesniffer.md)
-
-</details>
+- [PHPMD](./tools/php/phpmd.md)
+- [Phinder](./tools/php/phinder.md)
 
 ### Python
 
-<details open>
-  <summary>1 tool is available.</summary>
-
 - [Flake8](./tools/python/flake8.md)
-
-</details>
 
 ### Swift
 
-<details open>
-  <summary>1 tool is available.</summary>
-
 - [SwiftLint](./tools/swift/swiftlint.md)
-
-</details>
 
 ### Go
 
-<details open>
-  <summary>3 tools are available.</summary>
-
+- [GolangCI-Lint](./tools/go/golangci-lint.md)
 - [go vet](./tools/go/govet.md)
 - [Golint](./tools/go/golint.md)
 - [Go Meta Linter](./tools/go/gometalinter.md)
-- [GolangCI-Lint](./tools/go/golangci-lint.md)
-
-</details>
 
 ### C/C++
-
-<details open>
-  <summary>1 tool is available.</summary>
 
 - [Cppcheck](./tools/cplusplus/cppcheck.md)
 - [cpplint](./tools/cplusplus/cpplint.md)
 
-</details>
-
-### C#
-
-<details open>
-  <summary>1 tool is available.</summary>
+### C
 
 - [FxCop](./tools/csharp/fxcop.md)
 
-</details>
-
 ### Shell script
-
-<details open>
-  <summary>1 tool is available.</summary>
 
 - [ShellCheck](./tools/shellscript/shellcheck.md)
 
-</details>
-
 ### Dockerfile
-
-<details open>
-  <summary>1 tool is available.</summary>
 
 - [hadolint](./tools/dockerfile/hadolint.md)
 
-</details>
-
 ### Others
-
-<details open>
-  <summary>2 tools are available.</summary>
 
 - [Goodcheck](./tools/others/goodcheck.md)
 - [Misspell](./tools/others/misspell.md)
-
-</details>
 
 ## Custom Rules
 

--- a/docs/tools/cplusplus/cppcheck.md
+++ b/docs/tools/cplusplus/cppcheck.md
@@ -1,17 +1,17 @@
 ---
 id: cppcheck
 title: Cppcheck
-sidebar_label: Cppcheck
+sidebar_label: Cppcheck (beta)
 hide_title: true
 ---
 
 # Cppcheck
 
+> This is **BETA**. The behavior of this tool might change.
+
 | Supported Version | Language | Website                         |
 | :---------------- | :------- | :------------------------------ |
 | 1.90              | C/C++    | http://cppcheck.sourceforge.net |
-
-> This is **BETA**. The behavior of this tool might change.
 
 Cppcheck is a static analysis tool for C/C++ code. It aims to detect bugs, undefined behaviors, and dangerous coding constructs.
 

--- a/docs/tools/cplusplus/cpplint.md
+++ b/docs/tools/cplusplus/cpplint.md
@@ -1,17 +1,17 @@
 ---
 id: cpplint
 title: cpplint
-sidebar_label: cpplint
+sidebar_label: cpplint (beta)
 hide_title: true
 ---
 
 # cpplint
 
+> This is **BETA**. The behavior of this tool might change.
+
 | Supported Version | Language | Website                            |
 | ----------------- | -------- | ---------------------------------- |
 | 1.4.4             | C/C++    | https://github.com/cpplint/cpplint |
-
-> This is **BETA**. The behavior of this tool might change.
 
 Cpplint is a static analysis tool to check C/C++ files for style issues.
 

--- a/docs/tools/csharp/fxcop.md
+++ b/docs/tools/csharp/fxcop.md
@@ -1,13 +1,13 @@
 ---
 id: fxcop
 title: FxCop
-sidebar_label: FxCop
+sidebar_label: FxCop (beta)
 hide_title: true
 ---
 
 # FxCop
 
-> This is **not published yet**.
+> This is **BETA**. The behavior of this tool might change.
 
 | Supported Version | Language | Website                                                                    |
 | :---------------- | :------- | :------------------------------------------------------------------------- |

--- a/docs/tools/css/scss-lint.md
+++ b/docs/tools/css/scss-lint.md
@@ -1,18 +1,18 @@
 ---
 id: scss-lint
 title: SCSS-Lint
-sidebar_label: SCSS-Lint
+sidebar_label: SCSS-Lint (deprecated)
 hide_title: true
 ---
 
 # SCSS-Lint
 
+> **DEPRECATED**: Sider will no longer support SCSS-Lint because SCSS-Lint will stop its maintenance. We recommend [stylelint](https://stylelint.io) and [stylelint-scss](https://github.com/kristerkari/stylelint-scss) as an alternative.
+> For more details, see the [announce](https://github.com/sds/scss-lint#notice-consider-other-tools-before-adopting-scss-lint).
+
 | Supported Version | Language                      | Website                          |
 | ----------------- | ----------------------------- | -------------------------------- |
 | 0.59.0            | [Sass](https://sass-lang.com) | https://github.com/sds/scss-lint |
-
-> **DEPRECATED**: Sider will no longer support SCSS-Lint because SCSS-Lint will stop its maintenance. We recommend [stylelint](https://stylelint.io) and [stylelint-scss](https://github.com/kristerkari/stylelint-scss) as an alternative.
-> For more details, see the [announce](https://github.com/sds/scss-lint#notice-consider-other-tools-before-adopting-scss-lint).
 
 ## Getting Started
 

--- a/docs/tools/dockerfile/hadolint.md
+++ b/docs/tools/dockerfile/hadolint.md
@@ -1,17 +1,17 @@
 ---
 id: hadolint
 title: hadolint
-sidebar_label: hadolint
+sidebar_label: hadolint (beta)
 hide_title: true
 ---
 
 # hadolint
 
-| Supported Version | Language    | Website                             |
-| ----------------- | ----------- | ----------------------------------- |
-| 1.17.4            | Dockerfile  | https://github.com/hadolint/hadolint|
-
 > This is **BETA**. The behavior of this tool might change.
+
+| Supported Version | Language   | Website                              |
+| ----------------- | ---------- | ------------------------------------ |
+| 1.17.4            | Dockerfile | https://github.com/hadolint/hadolint |
 
 hadolint is a Dockerfile linter that helps you build best practice Docker images.
 
@@ -40,13 +40,13 @@ linter:
 
 You can use the following options to fine-tune hadolint to your project.
 
-| Name                                                                        | Type                 | Default      | Description                        |
-| --------------------------------------------------------------------------- | -------------------- | ------------ | ---------------------------------- |
-| [`root_dir`](../../getting-started/custom-configuration.md#root_dir-option) | `string`             |      -       | A root directory.                  |
-| [`target`](#target)                                                         | `string`, `string[]` | `**/Dockerfile{,.*}` | File paths to analyze.  |
-| [`ignore`](#ignore)                                                         | `string`, `string[]` |      -       | `--ignore` option of hadolint.     |
-| [`trusted-registry`](#trusted-registry)                                     | `string`, `string[]` |      -       | `--trusted-registry` option of hadolint.     |
-| [`config`](#config)                                                         | `string`             |      -       | `--config` option of hadolint.     |
+| Name                                                                        | Type                 | Default              | Description                              |
+| --------------------------------------------------------------------------- | -------------------- | -------------------- | ---------------------------------------- |
+| [`root_dir`](../../getting-started/custom-configuration.md#root_dir-option) | `string`             | -                    | A root directory.                        |
+| [`target`](#target)                                                         | `string`, `string[]` | `**/Dockerfile{,.*}` | File paths to analyze.                   |
+| [`ignore`](#ignore)                                                         | `string`, `string[]` | -                    | `--ignore` option of hadolint.           |
+| [`trusted-registry`](#trusted-registry)                                     | `string`, `string[]` | -                    | `--trusted-registry` option of hadolint. |
+| [`config`](#config)                                                         | `string`             | -                    | `--config` option of hadolint.           |
 
 ### `target`
 
@@ -71,6 +71,7 @@ linter:
       - "DL3002"
       - "DL3003"
 ```
+
 ### `trusted-registry`
 
 This option can warn you when images from untrusted repositories are being used in Dockerfiles. If you specify some trusted repositories, configure as follow:
@@ -81,6 +82,7 @@ linter:
     trusted-registry:
       - "my-company.com:500"
 ```
+
 ### `config`
 
 This option allow you to specify configuration file in yaml format like this [example](https://github.com/hadolint/hadolint#configure). If you specify path to configuration file, configure as follow:

--- a/docs/tools/go/golangci-lint.md
+++ b/docs/tools/go/golangci-lint.md
@@ -1,19 +1,19 @@
 ---
 id: golangci-lint
 title: GolangCI-Lint
-sidebar_label: GolangCI-Lint
+sidebar_label: GolangCI-Lint (beta)
 hide_title: true
 ---
 
 # GolangCI-Lint
 
+> This is **BETA**. The behavior of this tool might change.
+
 | Supported Version | Language  | Website                                   |
 | ----------------- | --------- | ----------------------------------------- |
 | 1.23.6            | Go 1.13.7 | https://github.com/golangci/golangci-lint |
 
-> This is **not published yet**.
-
-GolangCI-Lint is a linter to aggregate multiple linters and a successor to [Go Meta Linter](gometalinter.md) which is deprecated.
+**GolangCI-Lint** is a linter to aggregate multiple linters and a successor to [Go Meta Linter](gometalinter.md) which is deprecated.
 
 ## Getting Started
 

--- a/docs/tools/go/golint.md
+++ b/docs/tools/go/golint.md
@@ -1,17 +1,17 @@
 ---
 id: golint
 title: Golint
-sidebar_label: Golint
+sidebar_label: Golint (deprecated)
 hide_title: true
 ---
 
 # Golint
 
+> **DEPRECATED**: Sider will drop the support of Golint by **April 30, 2020**. We recommend [GolangCI-Lint](golangci-lint.md) as an alternative.
+
 | Language  | Website                        |
 | --------- | ------------------------------ |
 | Go 1.13.7 | https://github.com/golang/lint |
-
-> **DEPRECATED**: Sider will drop the support of Golint by **April 30, 2020**. We recommend [GolangCI-Lint](golangci-lint.md) as an alternative.
 
 ## Getting Started
 

--- a/docs/tools/go/gometalinter.md
+++ b/docs/tools/go/gometalinter.md
@@ -1,17 +1,17 @@
 ---
 id: gometalinter
 title: Go Meta Linter
-sidebar_label: Go Meta Linter
+sidebar_label: Go Meta Linter (deprecated)
 hide_title: true
 ---
 
 # Go Meta Linter
 
+> **DEPRECATED**: Sider will drop the support of Go Meta Linter by **April 30, 2020**. We recommend [GolangCI-Lint](golangci-lint.md) as an alternative.
+
 | Supported Version | Language  | Website                                    |
 | ----------------- | --------- | ------------------------------------------ |
 | 2.0.11            | Go 1.13.7 | https://github.com/alecthomas/gometalinter |
-
-> **DEPRECATED**: Sider will drop the support of Go Meta Linter by **April 30, 2020**. We recommend [GolangCI-Lint](golangci-lint.md) as an alternative.
 
 For more details, see the [readme](https://github.com/alecthomas/gometalinter#readme).
 

--- a/docs/tools/go/govet.md
+++ b/docs/tools/go/govet.md
@@ -1,17 +1,17 @@
 ---
 id: govet
 title: go vet
-sidebar_label: go vet
+sidebar_label: go vet (deprecated)
 hide_title: true
 ---
 
 # go vet
 
+> **DEPRECATED**: Sider will drop the support of go vet by **April 30, 2020**. We recommend [GolangCI-Lint](golangci-lint.md) as an alternative.
+
 | Language  | Website                    |
 | --------- | -------------------------- |
 | Go 1.13.7 | https://golang.org/cmd/vet |
-
-> **DEPRECATED**: Sider will drop the support of go vet by **April 30, 2020**. We recommend [GolangCI-Lint](golangci-lint.md) as an alternative.
 
 ## Getting Started
 

--- a/docs/tools/javascript/tslint.md
+++ b/docs/tools/javascript/tslint.md
@@ -1,11 +1,14 @@
 ---
 id: tslint
 title: TSLint
-sidebar_label: TSLint
+sidebar_label: TSLint (deprecated)
 hide_title: true
 ---
 
 # TSLint
+
+> **DEPRECATED**: TSLint has been deprecated and it recommends migrating to [TypeScript ESLint](https://github.com/typescript-eslint/typescript-eslint).
+> See the [discussion](https://github.com/palantir/tslint/issues/4534) for more details.
 
 | Supported Version         | Language   | Runtime         | Website                           |
 | ------------------------- | ---------- | --------------- | --------------------------------- |

--- a/docs/tools/kotlin/detekt.md
+++ b/docs/tools/kotlin/detekt.md
@@ -1,19 +1,19 @@
 ---
 id: detekt
 title: detekt
-sidebar_label: detekt
+sidebar_label: detekt (beta)
 hide_title: true
 ---
 
 # detekt
 
+> This is **BETA**. The behavior of this tool might change.
+
 | Supported Version | Language             | Website                              |
 | :---------------- | :------------------- | :----------------------------------- |
 | 1.6.0             | Kotlin (Java 12.0.2) | https://github.com/arturbosch/detekt |
 
-> This is **not published yet**.
-
-**detekt** is a linter which code smell analysis for your [Kotlin](https://kotlinlang.org) projects. 
+**detekt** is a linter which code smell analysis for your [Kotlin](https://kotlinlang.org) projects.
 
 ## Getting Started
 
@@ -29,16 +29,16 @@ Put the `detekt` key in `sider.yml` to customize the execution of detekt.
 linter:
   detekt:
     baseline: "baseline.xml"
-    config: 
+    config:
       - "path/to/detekt-config.yml"
       - "path/to/another/detekt-config.yml"
     config-resource: []
     disable-default-rulesets: false
-    excludes: 
+    excludes:
       - "**/excludes_dir/**"
       - "**/another/excludes_dir/**"
     includes: []
-    input: 
+    input:
       - "src/"
 ```
 
@@ -49,13 +49,13 @@ You can customize your detekt analysis using `sider.yml`.
 | Name                                                                        | Type                 | Default                   | Description                                                                                    |
 | --------------------------------------------------------------------------- | -------------------- | ------------------------- | ---------------------------------------------------------------------------------------------- |
 | [`root_dir`](../../getting-started/custom-configuration.md#root_dir-option) | `string`             | -                         | A root directory.                                                                              |
-| [`baseline`](#baseline)                                        　　　　　　　　| `string`             | -                         | Baseline file path.                                                                            |
-| [`config`](#config)                                            　　　　　　　　| `string`, `string[]` | `[]`                      | Config file paths.                                                                             |
-| [`config-resource`](#config-resource)                          　　　　　　　　| `string`, `string[]` | `[]`                      | Config resource paths.                                                                         |
-| [`disable-default-rulesets`](#disable-default-rulesets)        　　　　　　　　| `boolean`            | `false`                   | [`--disable-default-rulesets`](https://arturbosch.github.io/detekt/cli.html) option of detekt. |
-| [`excludes`](#excludes)                                        　　　　　　　　| `string`, `string[]` | `[]`                      | Exclude paths. (Globing patterns)                                                              |
-| [`includes`](#includes)                                        　　　　　　　　| `string`, `string[]` | `[]`                      | Include paths. (Globing patterns)                                                              |
-| [`input`](#input)                                              　　　　　　　　| `string`, `string[]` | current working directory | Input paths.                                                                                   |
+| [`baseline`](#baseline) 　　　　　　　　                                    | `string`             | -                         | Baseline file path.                                                                            |
+| [`config`](#config) 　　　　　　　　                                        | `string`, `string[]` | `[]`                      | Config file paths.                                                                             |
+| [`config-resource`](#config-resource) 　　　　　　　　                      | `string`, `string[]` | `[]`                      | Config resource paths.                                                                         |
+| [`disable-default-rulesets`](#disable-default-rulesets) 　　　　　　　　    | `boolean`            | `false`                   | [`--disable-default-rulesets`](https://arturbosch.github.io/detekt/cli.html) option of detekt. |
+| [`excludes`](#excludes) 　　　　　　　　                                    | `string`, `string[]` | `[]`                      | Exclude paths. (Globing patterns)                                                              |
+| [`includes`](#includes) 　　　　　　　　                                    | `string`, `string[]` | `[]`                      | Include paths. (Globing patterns)                                                              |
+| [`input`](#input) 　　　　　　　　                                          | `string`, `string[]` | current working directory | Input paths.                                                                                   |
 
 For example:
 
@@ -63,16 +63,16 @@ For example:
 linter:
   detekt:
     baseline: "baseline.xml"
-    config: 
+    config:
       - "path/to/detekt-config.yml"
       - "path/to/another/detekt-config.yml"
     config-resource: []
     disable-default-rulesets: false
-    excludes: 
+    excludes:
       - "**/excludes_dir/**"
       - "**/another/excludes_dir/**"
     includes: []
-    input: 
+    input:
       - "src/"
 ```
 

--- a/docs/tools/kotlin/ktlint.md
+++ b/docs/tools/kotlin/ktlint.md
@@ -1,7 +1,7 @@
 ---
 id: ktlint
 title: ktlint
-sidebar_label: ktlint
+sidebar_label: ktlint (beta)
 hide_title: true
 ---
 

--- a/docs/tools/python/flake8.md
+++ b/docs/tools/python/flake8.md
@@ -11,8 +11,6 @@ hide_title: true
 | ----------------- | ------------ | ----------------------- |
 | 3.7.9             | Python 3.7.4 | http://flake8.pycqa.org |
 
-> **DEPRECATED**: Sider will drop the support of Python 2, which will [be retired by April 2020](https://www.python.org/psf/press-release/pr20191220/). So, the `version` option of `sider.yml` and the detection of Python version via `.python-version` features are going to be unavailable near the future.
-
 ## Getting Started
 
 To start using Flake8, enable it in [Repository Settings](../../getting-started/repository-settings.md).
@@ -24,6 +22,8 @@ To customize Flake8, put a `.flake8` file in your repository.
 If your repository contains a `.python-version` file, the Python version is Sider will use the version specified in that file. You can also specify a Python version via `sider.yml`. The default is Python 3.
 
 The latest versions of Python 2 or Python 3 can be used.
+
+> **DEPRECATED**: Sider will drop the support of Python 2, which will [be retired by April 2020](https://www.python.org/psf/press-release/pr20191220/). So, the `version` option of `sider.yml` and the detection of Python version via `.python-version` features are going to be unavailable near the future.
 
 ## Default Configuration
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -47,9 +47,9 @@
         "ids": [
           "tools/javascript/eslint",
           "tools/javascript/jshint",
-          "tools/javascript/tslint",
           "tools/javascript/tyscan",
-          "tools/javascript/coffeelint"
+          "tools/javascript/coffeelint",
+          "tools/javascript/tslint"
         ]
       },
       {
@@ -64,9 +64,9 @@
         "type": "subcategory",
         "label": "PHP",
         "ids": [
-          "tools/php/phinder",
+          "tools/php/codesniffer",
           "tools/php/phpmd",
-          "tools/php/codesniffer"
+          "tools/php/phinder"
         ]
       },
       {
@@ -87,10 +87,10 @@
         "type": "subcategory",
         "label": "Go",
         "ids": [
+          "tools/go/golangci-lint",
           "tools/go/govet",
           "tools/go/golint",
-          "tools/go/gometalinter",
-          "tools/go/golangci-lint"
+          "tools/go/gometalinter"
         ]
       },
       {


### PR DESCRIPTION
- Remove `<details>` on the homepage.
- Fix the number of supported tools and languages.
- Add `(deprecated)` and `(beta)` tags on the left sidebar labels.
- Fix "not published". Fix #306 
- Make deprecations' position consistent.