### PR TITLE
Disable `remark-lint-no-dead-urls`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
-    "lint": "remark . --frail --quiet"
+    "lint": "remark . --frail --quiet",
+    "lint:no-dead-urls": "npm run lint -- --use lint-no-dead-urls"
   },
   "devDependencies": {
     "@arkweid/lefthook": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -23,9 +23,7 @@
       "lint-heading-increment",
       [
         "lint-no-dead-urls",
-        {
-          "skipLocalhost": true
-        }
+        false
       ],
       "lint-no-duplicate-headings",
       "lint-no-empty-url",


### PR DESCRIPTION
GitHub often returns "429 too many requests":

```
$ curl -I https://github.com/rubocop-hq/rubocop/releases/tag/v0.79.0
HTTP/1.1 429 too many requests
Date: Mon, 23 Mar 2020 14:40:22 GMT
Server: Varnish
Content-Type: text/html; charset=utf-8
Retry-After: 1m0s
Content-Length: 1650
X-GitHub-Request-Id: FBA5:793E:B89F05:FBB4E2:5E78CA56
X-Frame-Options: DENY
```