### PR TITLE
Reconfigure remark-lint

### DIFF
--- a/.remarkrc.yml
+++ b/.remarkrc.yml
@@ -1,0 +1,8 @@
+plugins:
+  - remark-frontmatter
+  - [remark-lint-first-heading-level, [error]]
+  - [remark-lint-heading-increment, [error]]
+  - [remark-lint-no-dead-urls, { skipLocalhost: true }]
+  - [remark-lint-no-duplicate-headings, [error]]
+  - [remark-lint-no-empty-url, [error]]
+  - [remark-validate-links, [error]]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "lint": "remark . --frail --quiet"
+    "lint": "remark . --quiet"
   },
   "devDependencies": {
     "@arkweid/lefthook": "^0.7.1",
@@ -14,22 +14,5 @@
     "remark-lint-no-duplicate-headings": "^1.0.4",
     "remark-lint-no-empty-url": "^1.0.5",
     "remark-validate-links": "^9.2.0"
-  },
-  "remarkConfig": {
-    "plugins": [
-      "frontmatter",
-      "lint",
-      "lint-first-heading-level",
-      "lint-heading-increment",
-      [
-        "lint-no-dead-urls",
-        {
-          "skipLocalhost": true
-        }
-      ],
-      "lint-no-duplicate-headings",
-      "lint-no-empty-url",
-      "validate-links"
-    ]
   }
 }


### PR DESCRIPTION
- Move the remark-lint configuration from `package.json` to `.remarkrc.yml`
- Change the rules' severity to `error` except for `remark-lint-no-dead-urls`
- Keep the severity of `remark-lint-no-dead-urls` as `warning`
  - Because GitHub often returns "429 too many requests" error
- Trim the `--frail` option of the `remark` command. This doesn't exit with 1 even if warnings are detected

Close #330