### PR TITLE
Add Runners version on the release notes

### DIFF
--- a/docs/enterprise/releases/202004.md
+++ b/docs/enterprise/releases/202004.md
@@ -21,6 +21,7 @@ This release includes the notable changes. Please check the list below.
 
 This release includes the following updates:
 
+- **Runners version**: [0.22.1](https://github.com/sider/runners/releases/tag/0.22.1)
 - [New remark-lint support and more](../../news/2020.md#new-remark-lint-support-and-more)
 - [New Reek options](../../news/2020.md#new-reek-options)
 - [Languages and tools update on March 25, 2020](../../news/2020.md#languages-and-tools-update-on-march-25-2020)


### PR DESCRIPTION
From the release `release-202004.0`, I want to add the Runners version in the "Features" section.