### PR TITLE
[Cppcheck] Improve document

### DIFF
--- a/docs/tools/cplusplus/cppcheck.md
+++ b/docs/tools/cplusplus/cppcheck.md
@@ -9,19 +9,19 @@ hide_title: true
 
 > This is **BETA**. The behavior of this tool might change.
 
-| Supported Version | Language | Website                         |
-| :---------------- | :------- | :------------------------------ |
-| 1.90              | C/C++    | http://cppcheck.sourceforge.net |
+| Supported Version | Language | Website                            |
+| ----------------- | -------- | ---------------------------------- |
+| 1.90              | C/C++    | https://github.com/danmar/cppcheck |
 
-Cppcheck is a static analysis tool for C/C++ code. It aims to detect bugs, undefined behaviors, and dangerous coding constructs.
+**Cppcheck** is a static analysis tool for C/C++ code. It aims to detect bugs, undefined behaviors, and dangerous coding constructs.
 
 ## Getting Started
 
 To start using Cppcheck, enable it in your [repository settings](../../getting-started/repository-settings.md).
 
-For more details, see the command-line help or the [online manual](http://cppcheck.sourceforge.net/manual.pdf).
+For more details, see the command-line help or the [online manual](https://github.com/danmar/cppcheck/blob/master/man/manual.md).
 
-```shell
+```console
 $ cppcheck --help
 ```
 
@@ -42,15 +42,15 @@ linter:
 
 You can use the following options to fine-tune Cppcheck to your project.
 
-| Name                                                                        | Type                 | Default | Description                      |
-| --------------------------------------------------------------------------- | -------------------- | ------- | -------------------------------- |
-| [`root_dir`](../../getting-started/custom-configuration.md#root_dir-option) | `string`             | -       | A root directory.                |
-| [`target`](#target)                                                         | `string`, `string[]` | `.`     | Files or directories to analyze. |
-| [`ignore`](#ignore)                                                         | `string`, `string[]` | -       | `-i` option of Cppcheck.         |
-| [`enable`](#enable)                                                         | `string`             | -       | `--enable` option of Cppcheck.   |
-| [`std`](#std)                                                               | `string`             | -       | `--std` option of Cppcheck.      |
-| [`project`](#project)                                                       | `string`             | -       | `--project` option of Cppcheck.  |
-| [`language`](#language)                                                     | `string`             | -       | `--language` option of Cppcheck. |
+| Name                                                                        | Type                 | Default |
+| --------------------------------------------------------------------------- | -------------------- | ------- |
+| [`root_dir`](../../getting-started/custom-configuration.md#root_dir-option) | `string`             | -       |
+| [`target`](#target)                                                         | `string`, `string[]` | `.`     |
+| [`ignore`](#ignore)                                                         | `string`, `string[]` | -       |
+| [`enable`](#enable)                                                         | `string`             | -       |
+| [`std`](#std)                                                               | `string`             | -       |
+| [`project`](#project)                                                       | `string`             | -       |
+| [`language`](#language)                                                     | `string`             | -       |
 
 ### `target`
 
@@ -67,7 +67,8 @@ linter:
 
 ### `ignore`
 
-This option allows you to exclude files or directories from analysis. If you specify multiple targets, configure as follow:
+This option allows you to exclude files or directories from analysis.
+If you specify multiple targets, configure as follow:
 
 ```yaml
 linter:
@@ -78,12 +79,11 @@ linter:
       - "you/ignore/code/here"
 ```
 
+See also the [`-i`](https://github.com/danmar/cppcheck/blob/master/man/manual.md#excluding-a-file-or-folder-from-checking).
+
 ### `enable`
 
-This option allows you to enable additional checks.
-For more details about the available values, see the command-line help.
-
-For example:
+This option allows you to enable additional checks. For example:
 
 ```yaml
 linter:
@@ -94,12 +94,13 @@ linter:
     # enable: "warning,style,unusedFunction"
 ```
 
+The available values are `all`, `warning`, `style`, `performance`, `portability`, `information`, `unusedFunction`, and `missingInclude`.
+
+See also the `--enable` option via the command-line help.
+
 ### `std`
 
-This option allows you to set the C/C++ standard version like [C99](https://en.wikipedia.org/wiki/C99).
-For more details about the available values, see the command-line help.
-
-For example:
+This option allows you to set the C/C++ standard version like [C99](https://en.wikipedia.org/wiki/C99). For example:
 
 ```yaml
 linter:
@@ -108,13 +109,19 @@ linter:
     # std: "c++11" # C++ code is C++11 compatible
 ```
 
+The available values are `c89`, `c99`, `c11`, `c++03`, `c++11`, `c++14`, `c++17`, and `c++20`.
+
+See also the `--std` option via the command-line help.
+
 ### `project`
 
 This option allows you to specify your project file.
-For more details about the available file format, see the command-line help.
-
 For example, if you want to analyze a Visual Studio Solution project, you may specify your project file with the file extension `.sln`.
+
+See also the `--project` option via the command-line help.
 
 ### `language`
 
-This option allows you to force analyzing code as a given language. The available values are: `c`, `c++`.
+This option allows you to force analyzing code as a given language. The available values are `c` and `c++`.
+
+See also the `--language` option via the command-line help.


### PR DESCRIPTION
- Replace sourceforge.net with github.com for the website. Because the former is often down.
- Drop the description column from the option table (see #358).
- Clarify the each option's description.