### PR TITLE
[Flake8] Improve document

### DIFF
--- a/docs/tools/python/flake8.md
+++ b/docs/tools/python/flake8.md
@@ -7,9 +7,11 @@ hide_title: true
 
 # Flake8
 
-| Supported Version | Language     | Website                 |
-| ----------------- | ------------ | ----------------------- |
-| 3.7.9             | Python 3.7.4 | http://flake8.pycqa.org |
+| Supported Version | Language     | Website                         |
+| ----------------- | ------------ | ------------------------------- |
+| 3.7.9             | Python 3.7.4 | https://gitlab.com/pycqa/flake8 |
+
+**Flake8** is a linter to check the style and quality of Python code.
 
 ## Getting Started
 
@@ -23,38 +25,17 @@ If your repository contains a `.python-version` file, the Python version is Side
 
 The latest versions of Python 2 or Python 3 can be used.
 
-> **DEPRECATED**: Sider will drop the support of Python 2, which will [be retired by April 2020](https://www.python.org/psf/press-release/pr20191220/). So, the `version` option of `sider.yml` and the detection of Python version via `.python-version` features are going to be unavailable near the future.
+> **DEPRECATED**: Sider will drop the support of Python 2, which will [be retired by April 2020](https://www.python.org/psf/press-release/pr20191220/).
+> So, the `version` option of `sider.yml` and the detection of Python version via `.python-version` features are going to be unavailable near the future.
 
-## Default Configuration
+## Default Configuration for Flake8
 
-Sider provides a default configuration for Flake8. If your repository does not include `.flake8`, `setup.cfg` or `tox.ini`, our default configuration will be used.
+Sider provides a [default configuration](https://github.com/sider/runners/blob/master/images/flake8/sider_config.ini) for Flake8.
+If your repository does not include `.flake8`, `setup.cfg` or `tox.ini`, the default configuration will be used.
 
-Our default configuration is here:
+## Configuration
 
-```ini
-[flake8]
-ignore =
-  # Ignore all warnings
-  W,
-  # Ignore all indentation rules
-  E1,
-  # Ignore all whitespace rules
-  E2,
-  # Ignore all blank line rules
-  E3,
-  # Ignore all import rules
-  E4,
-  # Ignore backslash style rule
-  E502,
-  # Ignore oneline statement rules
-  E70,
-
-max-line-length = 200
-```
-
-## Configuration via `sider.yml`
-
-Here are example settings for Flake8 under `flake8`:
+Here is an example configuration via `sider.yml`:
 
 ```yaml
 linter:
@@ -67,16 +48,19 @@ linter:
 
 You can use several options to fine-tune Flake8 to your project.
 
-| Name                                                                        | Type                 | Default | Description                                                            |
-| :-------------------------------------------------------------------------- | :------------------- | :------ | :--------------------------------------------------------------------- |
-| [`root_dir`](../../getting-started/custom-configuration.md#root_dir-option) | `string`             | -       | A root directory.                                                      |
-| [`version`](#version)                                                       | `integer`            | `3`     | **[DEPRECATED]** Specify Python version.                               |
-| [`plugins`](#plugins)                                                       | `string`, `string[]` | -       | Set Flake8 plugins. It also allows to specify these plugins' versions. |
+| Name                                                                        | Type                 | Default |
+| --------------------------------------------------------------------------- | -------------------- | ------- |
+| [`root_dir`](../../getting-started/custom-configuration.md#root_dir-option) | `string`             | -       |
+| [`version`](#version)                                                       | `integer`            | `3`     |
+| [`plugins`](#plugins)                                                       | `string`, `string[]` | -       |
 
 ### `version`
 
-This setting manages the Python version used when running `flake8`. Python 3 will be used if omitted.
+This option allows you to manage the Python version used when running `flake8`. Python 3 will be used if omitted.
+
+This option is **deprecated** and will be removed in the near future. See this [section](#python-version) for details.
 
 ### `plugins`
 
-This option allows you to enable Flake8 plugins. You can set arbitrary plugin names and also specify a _minimum_ version number. If no version is specified, Sider will install the latest version.
+This option allows you to enable Flake8 plugins. You can set arbitrary plugin names and also specify a _minimum_ version number.
+If no version is specified, Sider will install the latest version.


### PR DESCRIPTION
- Add a brief summary for the tool.
- Drop the description column from the option table (see #358).
- Replace the code snippet for the default configuration with just the link.