### PR TITLE
[ESLint] Replace default config snippet

### DIFF
--- a/docs/tools/javascript/eslint.md
+++ b/docs/tools/javascript/eslint.md
@@ -46,15 +46,8 @@ For more details, see the following sections.
 
 ## Default Configuration for ESLint
 
-Sider prepares the following ESLint configuration by default.
-The configuration is used when you have no ESLint configurations in your repository or `sider.yml`.
-
-```yaml
-extends: "eslint:recommended"
-rules:
-  no-undef: off
-  no-unused-vars: off
-```
+Sider prepares the [default ESLint configuration](https://github.com/sider/runners/blob/master/images/eslint/sider_eslintrc.yml).
+This configuration is used when you have no ESLint configurations or `sider.yml` in your repository.
 
 ## Configuration
 


### PR DESCRIPTION
This change replaces the default configuration snippet with just a lint to [sider/runners](https://github.com/sider/runners).