### PR TITLE
[stylelint] Improve document

### DIFF
--- a/docs/tools/css/stylelint.md
+++ b/docs/tools/css/stylelint.md
@@ -11,6 +11,9 @@ hide_title: true
 | :------------------------- | :-------------------------- | :-------------- | :------------------- |
 | 8.3.0+ (default to 13.2.0) | CSS and flavors (e.g. Sass) | Node.js 12.16.1 | https://stylelint.io |
 
+**stylelint** is a pluggable linter to help you avoid errors and enforce conventions for CSS and CSS-like languages.
+It provides many core rules and third-party rules by the community.
+
 ## Getting Started
 
 To start using stylelint, enable it in your [repository settings](../../getting-started/repository-settings.md).
@@ -27,71 +30,75 @@ Sider supports styelint plugins and configurations that are provided as npm pack
 
 If you need more customization, use the standard stylelint configuration files. For example, use `.stylelintrc.yaml` to customize rules, and `.stylelintignore` to ignore files and directories.
 
-## Default Configuration
+## Default Configuration for stylelint
 
-If you have no custom configuration, Sider uses the latest version of [stylelint-config-recommended](https://github.com/stylelint/stylelint-config-recommended).
+If you have no custom configurations, Sider uses the [default configuration](https://github.com/sider/runners/blob/master/images/stylelint/sider_recommended_config.yaml).
 
-```yaml
-extends: "stylelint-config-recommended"
-```
+In the same way, Sider users the [default ignore file](https://github.com/sider/runners/blob/master/images/stylelint/sider_recommended_stylelintignore) if not exist.
 
-Also, Sider ignores `*.min.css` files by default.
+## Configuration
 
-## Configuration via `sider.yml`
-
-Here is an example for stylelint:
+Here is an example configuration via `sider.yml`:
 
 ```yaml
 linter:
   stylelint:
     npm_install: false
+    glob: "**/*.{css,scss}"
     config: my_stylelintrc.yaml
     syntax: sugarss
     ignore-path: .gitignore
     ignore-disables: true
     report-needless-disables: true
     quiet: true
-    glob: "**/*.{css,scss}"
 ```
 
 You can use the following options to fine-tune stylelint to your project.
 
-| Name                                                                                        | Type                | Default                         | Description                                                                                                               |
-| ------------------------------------------------------------------------------------------- | ------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| [`root_dir`](../../getting-started/custom-configuration.md#linteranalyzer_idroot_dir)       | `string`            | -                               | A root directory.                                                                                                         |
-| [`npm_install`](../../getting-started/custom-configuration.md#linteranalyzer_idnpm_install) | `boolean`, `string` | -                               | A behavior of npm installation.                                                                                           |
-| [`config`](#config)                                                                         | `string`            | -                               | [`--config`](https://stylelint.io/user-guide/usage/options#configfile) option of stylelint.                               |
-| [`syntax`](#syntax)                                                                         | `string`            | -                               | [`--syntax`](https://stylelint.io/user-guide/usage/options#syntax) option of stylelint.                                   |
-| [`ignore-path`](#ignore-path)                                                               | `string`            | -                               | [`--ignore-path`](https://stylelint.io/user-guide/usage/options#ignorepath) option of stylelint.                          |
-| [`ignore-disables`](#ignore-disables)                                                       | `boolean`           | `false`                         | [`--ignore-disables`](https://stylelint.io/user-guide/usage/options#ignoredisables) option of stylelint.                  |
-| [`report-needless-disables`](#report-needless-disables)                                     | `boolean`           | `false`                         | [`--report-needless-disables`](https://stylelint.io/user-guide/usage/options#reportneedlessdisables) option of stylelint. |
-| [`quiet`](#quiet)                                                                           | `boolean`           | `false`                         | [`--quiet`](https://stylelint.io/user-guide/usage/cli#--quiet--q) option of stylelint.                                    |
-| [`glob`](#glob)                                                                             | `string`            | `**/*.{css,less,sass,scss,sss}` | A glob pattern to analyze.                                                                                                |
+| Name                                                                                        | Type                | Default                         |
+| ------------------------------------------------------------------------------------------- | ------------------- | ------------------------------- |
+| [`root_dir`](../../getting-started/custom-configuration.md#linteranalyzer_idroot_dir)       | `string`            | -                               |
+| [`npm_install`](../../getting-started/custom-configuration.md#linteranalyzer_idnpm_install) | `boolean`, `string` | -                               |
+| [`glob`](#glob)                                                                             | `string`            | `**/*.{css,less,sass,scss,sss}` |
+| [`config`](#config)                                                                         | `string`            | -                               |
+| [`syntax`](#syntax)                                                                         | `string`            | -                               |
+| [`ignore-path`](#ignore-path)                                                               | `string`            | -                               |
+| [`ignore-disables`](#ignore-disables)                                                       | `boolean`           | `false`                         |
+| [`report-needless-disables`](#report-needless-disables)                                     | `boolean`           | `false`                         |
+| [`quiet`](#quiet)                                                                           | `boolean`           | `false`                         |
 
-### `config`
-
-This option allows you to specify a configuration file except for the stylelint default file (e.g. `.stylelintrc.json`).
-
-### `syntax`
-
-This option allows you to control the non-standard syntaxes (e.g. `css-in-js`). In contrast, stylelint will automatically infer the standard syntaxes.
-
-### `ignore-path`
-
-This option allows you to exclude files from analysis. By default stylelint uses a `.stylelintignore` file, but if you want to use another file, set this option. For more details, see [the stylelint documentation](https://stylelint.io/user-guide/configuration#stylelintignore).
-
-### `ignore-disables`
-
-This option allows you to ignore all disable comments, i.e. `/* stylelint-disable block-no-empty */`.
-
-### `report-needless-disables`
-
-This option allows you to control whether `stylelint-disable` comments are reported or not.
-
-### `quiet`
-
-This option allows you to ignore warnings and only report errors.
+See also the [official document](https://stylelint.io/user-guide/usage/options) for details about each option.
 
 ### `glob`
 
-This option allows you to specify the files or directories to analyze.
+This option allows you to specify a files or directories to analyze. Glob patterns are available.
+
+### `config`
+
+This option allows you to specify a configuration file you want.
+See also the [`--config`](https://stylelint.io/user-guide/usage/options#configfile) option.
+
+### `syntax`
+
+This option allows you to specify a syntax you want. If omitted, stylelint automatically infers the syntaxes.
+See also the [`--syntax`](https://stylelint.io/user-guide/usage/options#syntax) option.
+
+### `ignore-path`
+
+This option allows you to specify a [ignore file](https://stylelint.io/user-guide/ignore-code).
+See also the [`--ignore-path`](https://stylelint.io/user-guide/usage/options#ignorepath) option.
+
+### `ignore-disables`
+
+This option allows you to ignore all the disable comments, e.g. `/* stylelint-disable block-no-empty */`.
+See also the [`--ignore-disables`](https://stylelint.io/user-guide/usage/options#ignoredisables) option.
+
+### `report-needless-disables`
+
+This option allows you to select whether reporting unused `stylelint-disable` comments or not.
+See also the [`--report-needless-disables`](https://stylelint.io/user-guide/usage/options#reportneedlessdisables) option.
+
+### `quiet`
+
+This option allows you to select whether ignoring warnings and reporting only errors.
+See also the [`--quiet`](https://stylelint.io/user-guide/usage/cli#--quiet--q) option.

--- a/docs/tools/css/stylelint.md
+++ b/docs/tools/css/stylelint.md
@@ -71,7 +71,7 @@ See also the [official document](https://stylelint.io/user-guide/usage/options) 
 
 ### `glob`
 
-This option allows you to specify a files or directories to analyze. Glob patterns are available.
+This option allows you to specify files or directories to analyze. Glob patterns are available.
 
 ### `config`
 
@@ -90,7 +90,7 @@ See also the [`--ignore-path`](https://stylelint.io/user-guide/usage/options#ign
 
 ### `ignore-disables`
 
-This option allows you to ignore all the disable comments, e.g. `/* stylelint-disable block-no-empty */`.
+This option allows you to ignore all the disable-comments, e.g. `/* stylelint-disable block-no-empty */`.
 See also the [`--ignore-disables`](https://stylelint.io/user-guide/usage/options#ignoredisables) option.
 
 ### `report-needless-disables`


### PR DESCRIPTION
- Add a brief summary.
- Replace the default configuration snippet with just a link.
- Drop the description column from the option table. (see #358)
- Clarify each option's description.