### PR TITLE
[GolangCI-Lint] Some improvements

### DIFF
--- a/docs/tools/go/golangci-lint.md
+++ b/docs/tools/go/golangci-lint.md
@@ -19,15 +19,28 @@ hide_title: true
 
 To start using GolangCI-Lint, enable it in your [repository settings](../../getting-started/repository-settings.md).
 
-## Default Configuration
+If you want to customize it, put a [configuration file](https://golangci-lint.run/usage/configuration/#config-file) (e.g. `.golangci.yml`) in your repository.
 
-In addition to [enabled by default linters](https://github.com/golangci/golangci-lint#enabled-by-default-linters), Sider enables some useful linters.
+## Default Configuration for GolangCI-Lint
+
+In addition to [enabled by default linters](https://golangci-lint.run/usage/linters/#enabled-by-default-linters), Sider enables some useful linters
+if you have no configuration file like `.golangci.yml`.
 See the [default configuration file](https://github.com/sider/runners/blob/master/images/golangci_lint/sider_golangci.yml) for details.
 
 ### Migration from Govet and Golint
 
 Sider has deprecated [Govet](./govet.md) and [Golint](./golint.md) and instead recommended GolangCI-Lint.
 If you want to continue using them, all you have to do is enable GolangCI-Lint. They are enabled by default.
+
+If you want to run only Govet or Golint as before, edit your configuration file as follows:
+
+```yaml
+# .golangci.yml
+linters:
+  disable-all: true
+  enable:
+    - govet # or golint
+```
 
 ## Configuration
 
@@ -77,6 +90,8 @@ You can use the following options to fine-tune GolangCI-Lint to your project.
 | [`tests`](#tests)                                                                     | `boolean`            | `true`  |
 | [`uniq-by-line`](#uniq-by-line)                                                       | `boolean`            | `true`  |
 
+See also the [official document](https://golangci-lint.run/usage/configuration/#command-line-options) about the command-line options.
+
 ### `target`
 
 This option allows you to specify files or directories to analyze. If you specify some targets, configure as follow:
@@ -92,61 +107,49 @@ linter:
 ### `config`
 
 This option allows you to control a configuration file. If you have settings file for GolangCI-Lint, put the path of that in this option.
-See also the [`--config`](https://github.com/golangci/golangci-lint#command-line-options) option.
 
 ### `no-config`
 
 This option allows you not to read config file.
-See also the [`--no-config`](https://github.com/golangci/golangci-lint#command-line-options) option.
 
 ### `disable`
 
 This option allows you to disable defaultly enabled linters. Set linters as a list in this option.
-See also the [`--disable`](https://github.com/golangci/golangci-lint#command-line-options) option.
 
 ### `disable-all`
 
 This option allows you to decide whether to disable all linters.
 Note that the option cannot be used with the [`disable`](#disable) option.
-See also the [`--disable-all`](https://github.com/golangci/golangci-lint#command-line-options) option.
 
 ### `enable`
 
 This option allows you to enable linters which are not defaultly enabled. Set linters as a list in this option.
 To specify `disable` and `enable` to the same linter is prohibited.
-See also the [`--enable`](https://github.com/golangci/golangci-lint#command-line-options) option.
 
 ### `fast`
 
-This option allows you to manage whether to run only [fast linters](https://github.com/golangci/golangci-lint#quick-start).
-See also the [`--fast`](https://github.com/golangci/golangci-lint#command-line-options) option.
+This option allows you to select whether to run only the fast linters.
 
 ### `presets`
 
-This option allows you to enable presets of linters.
-See also the [`--presets`](https://github.com/golangci/golangci-lint#command-line-options) option.
+This option allows you to enable presets of the linters.
 
 ### `skip-dirs`
 
 This option allows you to specify the directories to skip.
-See also the [`--skip-dirs`](https://github.com/golangci/golangci-lint#command-line-options) option.
 
 ### `skip-dirs-use-default`
 
 This option allows you to use or not use default excluded directories.
-See also the [`--skip-dirs-use-default`](https://github.com/golangci/golangci-lint#command-line-options) option.
 
 ### `skip-files`
 
 This option allows you to specify the files to skip.
-See also the [`--skip-files`](https://github.com/golangci/golangci-lint#command-line-options) option.
 
 ### `tests`
 
-This option allows you to decide whether to analyze test files. If you would like to include test files, set `true` in this option.
-See also the [`--tests`](https://github.com/golangci/golangci-lint#command-line-options) option.
+This option allows you to select whether to analyze test files. If you would like to include test files, set `true` in this option.
 
 ### `uniq-by-line`
 
 This option allows you to show multiple linters per line. If you would like to show multiple linters per line, set `false` in this option.
-See also the [`--uniq-by-line`](https://github.com/golangci/golangci-lint#command-line-options) option.


### PR DESCRIPTION
- Fix the links for the new website (https://golangci-lint.run).
- Add a description about `.golangci.yml`.
- Add a description about the Govet or Golint users.