### PR TITLE
Add description about `linter.*` options of `sider.yml`

### DIFF
--- a/docs/getting-started/custom-configuration.md
+++ b/docs/getting-started/custom-configuration.md
@@ -29,14 +29,55 @@ linter:
   stylelint:
     root_dir: "app/assets/stylesheets"
     glob: "**/*.{css,scss}"
+
+ignore:
+  - "images/**"
 ```
 
 The options you can specify in `sider.yml` are grouped into the following categories:
 
-1. Analyzer specific options (`linter.<analyzer_id>.*`)
-2. Analysis options (e.g. `ignore`)
+1. Analyzer-specific options (under `linter`)
+   - [`linter.brakeman`](../tools/ruby/brakeman.md)
+   - [`linter.checkstyle`](../tools/java/checkstyle.md)
+   - [`linter.code_sniffer`](../tools/php/codesniffer.md)
+   - [`linter.coffeelint`](../tools/javascript/coffeelint.md)
+   - [`linter.cppcheck`](../tools/cplusplus/cppcheck.md)
+   - [`linter.cpplint`](../tools/cplusplus/cpplint.md)
+   - [`linter.detekt`](../tools/kotlin/detekt.md)
+   - [`linter.eslint`](../tools/javascript/eslint.md)
+   - [`linter.flake8`](../tools/python/flake8.md)
+   - [`linter.fxcop`](../tools/csharp/fxcop.md)
+   - [`linter.go_vet`](../tools/go/govet.md)
+   - [`linter.golangci_lint`](../tools/go/golangci-lint.md)
+   - [`linter.golint`](../tools/go/golint.md)
+   - [`linter.gometalinter`](../tools/go/gometalinter.md)
+   - [`linter.goodcheck`](../tools/others/goodcheck.md)
+   - [`linter.hadolint`](../tools/dockerfile/hadolint.md)
+   - [`linter.haml_lint`](../tools/ruby/haml-lint.md)
+   - [`linter.javasee`](../tools/java/javasee.md)
+   - [`linter.jshint`](../tools/javascript/jshint.md)
+   - [`linter.ktlint`](../tools/kotlin/ktlint.md)
+   - [`linter.languagetool`](../tools/others/languagetool.md)
+   - [`linter.misspell`](../tools/others/misspell.md)
+   - [`linter.phinder`](../tools/php/phinder.md)
+   - [`linter.phpmd`](../tools/php/phpmd.md)
+   - [`linter.pmd_java`](../tools/java/pmd.md)
+   - [`linter.querly`](../tools/ruby/querly.md)
+   - [`linter.rails_best_practices`](../tools/ruby/rails-bestpractices.md)
+   - [`linter.reek`](../tools/ruby/reek.md)
+   - [`linter.remark_lint`](../tools/markdown/remark-lint.md)
+   - [`linter.rubocop`](../tools/ruby/rubocop.md)
+   - [`linter.scss_lint`](../tools/css/scss-lint.md)
+   - [`linter.shellcheck`](../tools/shellscript/shellcheck.md)
+   - [`linter.stylelint`](../tools/css/stylelint.md)
+   - [`linter.swiftlint`](../tools/swift/swiftlint.md)
+   - [`linter.tslint`](../tools/javascript/tslint.md)
+   - [`linter.tyscan`](../tools/javascript/tyscan.md)
+2. Non analyzer-specific options
+   - [`ignore`](#ignore)
+   - [`branches.exclude`](#branchesexclude)
 
-### Analyzer specific options
+### Analyzer-specific options
 
 You can use `sider.yml` to configure each analyzer's vendor-supplied settings.
 Sider also provides extra options for some analyzers that configure how Sider runs the analyzer (for example, some tools might need to run `npm install` before beginning analysis).

--- a/docs/tools/go/golint.md
+++ b/docs/tools/go/golint.md
@@ -15,8 +15,18 @@ hide_title: true
 
 ## Getting Started
 
-To start using Golint, enable Golint in repository setting.
+To start using Golint, enable it in your [repository settings](../../getting-started/repository-settings.md).
 
 ## Configuration
 
-There is no configuration available.
+Here is a configuration example via [`sider.yml`](../../getting-started/custom-configuration.md):
+
+```yaml
+linter:
+  golint:
+    root_dir: src/
+```
+
+| Name                                                                                  | Type     | Default |
+| ------------------------------------------------------------------------------------- | -------- | ------- |
+| [`root_dir`](../../getting-started/custom-configuration.md#linteranalyzer_idroot_dir) | `string` | -       |

--- a/docs/tools/go/govet.md
+++ b/docs/tools/go/govet.md
@@ -15,8 +15,18 @@ hide_title: true
 
 ## Getting Started
 
-To start using go vet, enable it in repository setting.
+To start using go vet, enable it in your [repository settings](../../getting-started/repository-settings.md).
 
 ## Configuration
 
-There is no configuration available.
+Here is a configuration example via [`sider.yml`](../../getting-started/custom-configuration.md):
+
+```yaml
+linter:
+  go_vet:
+    root_dir: src/
+```
+
+| Name                                                                                  | Type     | Default |
+| ------------------------------------------------------------------------------------- | -------- | ------- |
+| [`root_dir`](../../getting-started/custom-configuration.md#linteranalyzer_idroot_dir) | `string` | -       |


### PR DESCRIPTION
It seems hard for users to configure `sider.yml` (e.g. typos of `govet` and `go_vet`).
So, this change aims to help uses understand how to configure and fix `sider.yml`.

This also adds the missing options tables for Golint and Govet.