### PR TITLE
Do not use `rails secret`

### DIFF
--- a/docs/enterprise/config.md
+++ b/docs/enterprise/config.md
@@ -20,7 +20,13 @@ These parameters are not related to other services, like MySQL.
 - `SECRET_KEY_BASE` - (Required) The secret for encryption required by Ruby on Rails. You can get the value running the following command:
 
   ```console
-  docker run --rm 480130971618.dkr.ecr.us-east-1.amazonaws.com/sideci_onprem:TAG bundle exec rails secret
+  python -c 'import secrets; print(secrets.token_hex(64))'
+  ```
+
+  Or, you can get the value via Ruby:
+
+  ```console
+  ruby -r securerandom -e 'puts(SecureRandom.hex(64))'
   ```
 
 - `BASE_URL` - (Required) The URL to allow end-users to access Sider. e.g., `https://sider.example.com`.


### PR DESCRIPTION
Sider Enterprise requires environment variables before executing any Rails tasks, so I replaced the example command.

```console
$ python -c 'import secrets; print(secrets.token_hex(64))'
db80c184fa1899d795f38b44af3842b255d74a7802f0e6ef5009e7c78960e3c8679515f000858e52df88d44d817e705273f1b1c3b1c96a7911698b78b699ceb0
$ ruby -r securerandom -e 'puts(SecureRandom.hex(64))'
7f501e215c1727a6ae78c4e06beca74032f512e969224d3ce503a99abcd7188a9e4a92a6967a379c13c95c0c56bc38e2a9daa0121c1a9a5849d11b9baecc5fc4
```