### PR TITLE
Fix dead URLs

### DIFF
--- a/docs/enterprise/config.md
+++ b/docs/enterprise/config.md
@@ -67,7 +67,7 @@ You have to configure these parameters to integrate with GitHub Enterprise Serve
 
 - `GITHUB_ENDPOINT` - (Required) The URL which points to the GitHub Enterprise web page. e.g., `https://github.example.com`.
 
-- `GITHUB_API_ENDPOINT` - (Required) The URL which points to the GitHub Enterprise API endpoint. Basically, the suffix of this URL must be `/api/v3`. See [Endpoint URLs](https://developer.github.com/enterprise/v3/enterprise-admin/) to learn more about the GitHub Enterprise endpoints. e.g., `https://github.example.com/api/v3`.
+- `GITHUB_API_ENDPOINT` - (Required) The URL which points to the GitHub Enterprise API endpoint. Basically, the suffix of this URL must be `/api/v3`. See [Endpoint URLs](https://docs.github.com/en/enterprise/2.21/user/rest/reference/enterprise-admin) to learn more about the GitHub Enterprise endpoints. e.g., `https://github.example.com/api/v3`.
 
 - `GITHUB_APP_ID` - (Required) The application ID of the GitHub App. This will be given after setting up your GitHub App. See [GitHub Enterprise Server](./github.md) for registering a GitHub App.
 

--- a/docs/enterprise/github.md
+++ b/docs/enterprise/github.md
@@ -19,7 +19,7 @@ In addition, you must synchronize Time between GitHub Enterprise Server and Side
 
 ## Registering a GitHub App
 
-Create a new GitHub App on your GitHub Enterprise Server. Read the [Creating a GitHub App](https://developer.github.com/enterprise/apps/building-github-apps/creating-a-github-app/) for details.
+Create a new GitHub App on your GitHub Enterprise Server. Read the [Creating a GitHub App](https://docs.github.com/en/enterprise/2.21/user/developers/apps/creating-a-github-app) for details.
 
 The new GitHub App should have the following properties.
 

--- a/docs/tools/cplusplus/cppcheck.md
+++ b/docs/tools/cplusplus/cppcheck.md
@@ -19,7 +19,7 @@ hide_title: true
 
 To start using Cppcheck, enable it in your [repository settings](../../getting-started/repository-settings.md).
 
-For more details, see the command-line help or the [online manual](https://github.com/danmar/cppcheck/blob/master/man/manual.md).
+For more details, see the command-line help or the [online manual](https://github.com/danmar/cppcheck/blob/main/man/manual.md).
 
 ```console
 $ cppcheck --help
@@ -83,7 +83,7 @@ linter:
       - "you/ignore/code/here"
 ```
 
-See also the [`-i`](https://github.com/danmar/cppcheck/blob/master/man/manual.md#excluding-a-file-or-folder-from-checking).
+See also the [`-i`](https://github.com/danmar/cppcheck/blob/main/man/manual.md#excluding-a-file-or-folder-from-checking).
 
 ### `enable`
 
@@ -132,7 +132,7 @@ See also the `--language` option via the command-line help.
 
 ### `addon`
 
-This option allows you to set the [predefined addons](https://github.com/danmar/cppcheck/tree/master/addons#readme). For example:
+This option allows you to set the [predefined addons](https://github.com/danmar/cppcheck/tree/main/addons#readme). For example:
 
 ```yaml
 linter:
@@ -144,7 +144,7 @@ linter:
 
 The available values are `cert`, `misra`, `y2038`, and `threadsafety`.
 
-You can also specify a json file containing [the configuration of addons](https://github.com/danmar/cppcheck/blob/master/man/manual.md#running-addons). For example:
+You can also specify a json file containing [the configuration of addons](https://github.com/danmar/cppcheck/blob/main/man/manual.md#running-addons). For example:
 
 ```yaml
 linter:
@@ -166,4 +166,4 @@ The `config/misra.json` file goes like this:
 
 ### `bug-hunting`
 
-This option allows you to enable Bug hunting. There is a new "soundy" analysis introduced in Cppcheck-2.0. You can read more about this analysis in the [Cppcheck manual](https://github.com/danmar/cppcheck/blob/master/man/manual.md#bug-hunting).
+This option allows you to enable Bug hunting. There is a new "soundy" analysis introduced in Cppcheck-2.0. You can read more about this analysis in the [Cppcheck manual](https://github.com/danmar/cppcheck/blob/main/man/manual.md#bug-hunting).

--- a/docs/tools/markdown/remark-lint.md
+++ b/docs/tools/markdown/remark-lint.md
@@ -15,13 +15,13 @@ hide_title: true
 
 **remark-lint** is a pluggable linter for Markdown. It includes many rules to enforce consistency and detect possible mistakes.
 
-¹ Note that this version is actually [remark-cli](https://github.com/remarkjs/remark/tree/master/packages/remark-cli)'s, not remark-lint's. Sider requires only remark-cli.
+¹ Note that this version is actually [remark-cli](https://www.npmjs.com/package/remark-cli)'s, not remark-lint's. Sider requires only remark-cli.
 
 ## Getting Started
 
 To start using remark-lint, enable it in your [repository settings](../../getting-started/repository-settings.md).
 
-Sider enables [some useful rules](https://github.com/sider/remark-preset-lint-sider) by default, so you can get started out of the box.
+Sider enables [some useful rules](https://www.npmjs.com/package/remark-preset-lint-sider) by default, so you can get started out of the box.
 
 In addition, you can use some rules or plugins as you want. If doing so, you need to install remark-lint on your repository via npm, for example:
 
@@ -72,7 +72,7 @@ You can use the following options to fine-tune remark-lint to your project:
 | [`ignore-path`](#ignore-path)                                                               | `string`             | -       |
 | [`use`](#use)                                                                               | `string`, `string[]` | -       |
 
-For more details about the CLI options of remark-lint, see the [document](https://github.com/remarkjs/remark/tree/master/packages/remark-cli#cli).
+For more details about the CLI options of remark-lint, see the [document](https://www.npmjs.com/package/remark-cli#cli).
 
 ### `target`
 
@@ -115,7 +115,7 @@ linter:
 
 ### `ignore-path`
 
-This option allows you to specify a [`.remarkignore` file](https://github.com/unifiedjs/unified-engine/blob/master/doc/ignore.md).
+This option allows you to specify a [`.remarkignore` file](https://www.npmjs.com/package/unified-engine#ignoring).
 By default, remark-lint automatically finds a ignore file in a project, so you may not usually need to use this option.
 
 For example:
@@ -142,7 +142,7 @@ linter:
 
 ## Configuration files for remark-lint
 
-remark-lint has [own mechanism to use configuration files](https://github.com/unifiedjs/unified-engine/blob/master/doc/configure.md) such as `.remarkrc`, `.remarkrc.yml`, or `package.json`.
+remark-lint has [own mechanism to use configuration files](https://www.npmjs.com/package/unified-engine#configuration) such as `.remarkrc`, `.remarkrc.yml`, or `package.json`.
 
 For example, you can configure plugins via the following `.remarkrc.yml` file:
 


### PR DESCRIPTION
- The default branches were changed from `master` to `main`.
- developer.github.com was unified to docs.github.com (actually deprecated still, not dead)
  See https://github.blog/2020-07-01-launching-docs-github-com/