### PR TITLE
[Misspell] Allow `string` type for `target` option

### DIFF
--- a/docs/tools/others/misspell.md
+++ b/docs/tools/others/misspell.md
@@ -43,7 +43,7 @@ You can use several options to more comfortable analysis to your project.
 | Name                                                                                  | Type                 | Default |
 | ------------------------------------------------------------------------------------- | -------------------- | ------- |
 | [`root_dir`](../../getting-started/custom-configuration.md#linteranalyzer_idroot_dir) | `string`             | -       |
-| [`target`](#target)                                                                   | `string[]`           | `.`     |
+| [`target`](#target)                                                                   | `string`, `string[]` | `.`     |
 | [`exclude`](#exclude)                                                                 | `string[]`           | `[]`    |
 | [`locale`](#locale)                                                                   | `"US"`, `"UK"`       | -       |
 | [`ignore`](#ignore)                                                                   | `string`, `string[]` | -       |


### PR DESCRIPTION
https://github.com/sider/runners/blob/0.36.1/lib/runners/processor/misspell.rb#L8