### PR TITLE
Fix MySQL connection URL

### DIFF
--- a/docs/enterprise/config.md
+++ b/docs/enterprise/config.md
@@ -57,7 +57,7 @@ These parameters are not related to other services, like MySQL.
 
 Sider Enterprise completely depends on MySQL. You should carefully set up the parameters to accord with the actual MySQL configuration. Read [MySQL](./mysql.md) for how to configure a MySQL server.
 
-- `DATABASE_URL` - (Required) The URL to connect the MySQL server. The format of this parameter must be `mysql2://USER:PASSWORD@MYSQL_HOST:MYSQL_PORT/DATABASE_NAME?encoding=utf8mb4&connectTimeout=5000`. Note the query parameters `encoding=utf8mb4` and `connectTimeout=5000` should be placed as they are. e.g., `mysql2://sider:topsecret@mysql.example.com:3306/sideci?encoding=utf8mb4&connectTimeout=5000`.
+- `DATABASE_URL` - (Required) The URL to connect the MySQL server. See the [document](./mysql.md#integration-with-sider-enterprise) about the format.
 
 ## Redis
 

--- a/docs/enterprise/examples/single-node-with-docker-compose.md
+++ b/docs/enterprise/examples/single-node-with-docker-compose.md
@@ -36,7 +36,7 @@ Create `/etc/sider/env` with content like this, and change the file permission a
 ```bash:/etc/sider/env
 RAILS_ENV=onprem
 SECRET_KEY_BASE=81efee29dbcad46f33f366f8e55e8a4b29d199b4a5f3b82c55dddab5b3107e3cf656d5ab713bdf871a2d4128334933d08bbcee49a0b0cb18d1b54af6866e7b75
-DATABASE_URL=mysql2://mysql:3306/sideci?encoding=utf8mb4&connectTimeout=5000
+DATABASE_URL=mysql2://mysql:3306/sideci
 BASE_URL=https://sider.example.com
 REDIS_URL=redis://redis:6379/0
 GITHUB_APP_ID=1

--- a/docs/enterprise/installation.md
+++ b/docs/enterprise/installation.md
@@ -42,7 +42,7 @@ This is an example of the environment variables file located in `/etc/sider-env`
 ```bash:/etc/sider-env
 RAILS_ENV=onprem
 SECRET_KEY_BASE=topsecret...
-DATABASE_URL=mysql2://mysql.example.com:3306/sideci?encoding=utf8mb4&connectTimeout=5000
+DATABASE_URL=mysql2://mysql.example.com:3306/sideci
 BASE_URL=https://sider.example.com
 REDIS_URL=redis://redis.example.com:6379/0
 GITHUB_APP_ID=1

--- a/docs/enterprise/mysql.md
+++ b/docs/enterprise/mysql.md
@@ -27,14 +27,19 @@ You should configure these parameters to handle any requests from Sider Enterpri
 
 ## Integration with Sider Enterprise
 
-The parameter [`DATABASE_URL`](./config.md) of Sider Enterprise sees these items:
+The [`DATABASE_URL`](./config.md#mysql) of Sider Enterprise is configured as follows:
 
-- USER - MySQL user name to be used when connecting to the server
-- PASSWORD - The password to use when connecting to the server
-- MYSQL_HOST - The host name of the MySQL server
-- MYSQL_PORT - The port number of the MySQL server
-- DATABASE_NAME - The database name for Sider Enterprise
+```
+mysql2://{USER}:{PASSWORD}@{HOST}:{PORT}/{DATABASE_NAME}?{OPTION1}={VALUE1}&{OPTION2}={VALUE2}
+```
 
-When setting up your MySQL server, you will create USER and its PASSWORD first. Sider Enterprise will try to create the specified DATABASE_NAME unless it does not exist, so the USER should have strong privileges. If you don't want to pass such powerful permissions to the USER, create the DATABASE_NAME on your own, and allow the USER to do ALL operations only for the DATABASE_NAME.
+- `USER` - The user name to use when connecting to the MySQL server
+- `PASSWORD` - The password to use when connecting to the MySQL server
+- `HOST` - The host name of the MySQL server
+- `PORT` - The port number of the MySQL server
+- `DATABASE_NAME` - The database name for Sider Enterprise
+- `OPTION1=VALUE1`, `OPTION2=VALUE2`, ... - The query parameters to configure the connection
 
-Also, confirm Sider Enterprise services can access to the MySQL server via the specified MYSQL_HOST and MYSQL_PORT.
+When setting up your MySQL server, you will create `USER` and its `PASSWORD` first. Sider Enterprise will try to create the specified `DATABASE_NAME` unless it does not exist, so the `USER` should have strong privileges. If you don't want to pass such powerful permissions to the `USER`, create the `DATABASE_NAME` on your own, and allow the `USER` to do ALL operations only for the `DATABASE_NAME`.
+
+Also, confirm Sider Enterprise services can access to the MySQL server via the specified `HOST` and `PORT`.


### PR DESCRIPTION
This change mainly removes the needless query parameters of the MySQL connection URL (`DATABASE_URL`).

- `encoding=utf8mb4` - it's automatically set by default
- `connectTimeout=5000` - it's an invalid parameter (just ignored)

See the [`mysql2`](https://github.com/brianmario/mysql2) document for more details about the URL format and available parameters.

Also, this change unifies the pages to describe the URL.