### PR TITLE
Drop the support of Python 2

### DIFF
--- a/docs/tools/python/flake8.md
+++ b/docs/tools/python/flake8.md
@@ -9,7 +9,7 @@ hide_title: true
 
 | Supported Version | Language     | Website                         |
 | ----------------- | ------------ | ------------------------------- |
-| 3.8.3             | Python 3.8.6 | https://gitlab.com/pycqa/flake8 |
+| 3.8.3             | Python 3.8.5 | https://gitlab.com/pycqa/flake8 |
 
 **Flake8** is a linter to check the style and quality of Python code.
 

--- a/docs/tools/python/flake8.md
+++ b/docs/tools/python/flake8.md
@@ -9,7 +9,7 @@ hide_title: true
 
 | Supported Version | Language     | Website                         |
 | ----------------- | ------------ | ------------------------------- |
-| 3.8.3             | Python 3.8.5 | https://gitlab.com/pycqa/flake8 |
+| 3.8.3             | Python 3.8.6 | https://gitlab.com/pycqa/flake8 |
 
 **Flake8** is a linter to check the style and quality of Python code.
 
@@ -18,15 +18,6 @@ hide_title: true
 To start using Flake8, enable it in your [repository settings](../../getting-started/repository-settings.md).
 
 To customize Flake8, put a `.flake8` file in your repository.
-
-## Python Version
-
-If your repository contains a `.python-version` file, the Python version is Sider will use the version specified in that file. You can also specify a Python version via `sider.yml`. The default is Python 3.
-
-The latest versions of Python 2 or Python 3 can be used.
-
-> **DEPRECATED**: Sider will drop the support of Python 2, which will [be retired by April 2020](https://www.python.org/psf/press-release/pr20191220/).
-> So, the `version` option of `sider.yml` and the detection of Python version via `.python-version` features are going to be unavailable near the future.
 
 ## Default Configuration for Flake8
 
@@ -64,12 +55,6 @@ This option allows you to specify files or directories to analyze.
 ### `config`
 
 This option allows you to specify a configuration file you want to use.
-
-### `version`
-
-This option allows you to manage the Python version used when running `flake8`. Python 3 will be used if omitted.
-
-> **DEPRECATED**: This option is deprecated and will be removed in the near future. See ["Python Version"](#python-version) for details.
 
 ### `plugins`
 

--- a/docs/tools/python/pylint.md
+++ b/docs/tools/python/pylint.md
@@ -11,7 +11,7 @@ hide_title: true
 
 | Supported Version | Language     | Website                             |
 | ----------------- | ------------ | ----------------------------------- |
-| 2.6.0             | Python 3.8.6 | https://pylint.pycqa.org/en/stable/ |
+| 2.6.0             | Python 3.8.5 | https://pylint.pycqa.org/en/stable/ |
 
 **Pylint** is a Python static code analysis tool which looks for programming errors, helps to enforce a coding standard, sniffs for code smells and offers simple refactoring suggestions.
 

--- a/docs/tools/python/pylint.md
+++ b/docs/tools/python/pylint.md
@@ -11,7 +11,7 @@ hide_title: true
 
 | Supported Version | Language     | Website                             |
 | ----------------- | ------------ | ----------------------------------- |
-| 2.6.0             | Python 3.8.5 | https://pylint.pycqa.org/en/stable/ |
+| 2.6.0             | Python 3.8.6 | https://pylint.pycqa.org/en/stable/ |
 
 **Pylint** is a Python static code analysis tool which looks for programming errors, helps to enforce a coding standard, sniffs for code smells and offers simple refactoring suggestions.
 


### PR DESCRIPTION
Following https://github.com/sider/devon_rex/pull/307 and https://github.com/sider/runners/pull/1579, I want to update the documentation.

Note I kept the version of Flake8 and PyLint deliberately. If I should update these versions, please comment here.