### PR TITLE
Rewrite "Private Dependencies" page

### DIFF
--- a/docs/advanced-settings/private-dependencies.md
+++ b/docs/advanced-settings/private-dependencies.md
@@ -7,46 +7,124 @@ hide_title: true
 
 # Private Dependencies
 
-Analyzing a private project sometimes needs access to another private repository. Your team might be using a Git repository to distribute a private library. This kind of dependency is supported in some tools including Bundler, npm.
+Analyzing a private project sometimes needs access to other private libraries or packages hosted on private repositories.
+Your team might be using a Git repository to distribute such private libraries.
+Such a kind of dependencies is supported by some package managers like Bundler or npm.
 
-We support using SSH to access a private repository during an analysis session.
+We support accessing to private repositories via SSH during an analysis session.
+Let's check the following steps out.
 
-## Generating an SSH private key
+## Generate SSH key pair
+
+First of all, you need to generate an SSH key pair on your repository settings on Sider.
+
+Visit **Settings** on your repository, and then click **Keys**.
 
 ![Generate SSH private key](../assets/ssh-key-generate-key.png)
 
-When you click the **"Generate Key"** button, Sider generates a 4096 bit RSA key used in analysis sessions automatically.
+When you click **Generate Key**, Sider automatically generates a 4096-bit RSA key pair used for the private dependencies resolution.
 
-> We strongly recommend against adding secret keys to public repositories. Their analysis results are publicly accessible, and your secret keys might get exposed.
+> NOTE: We strongly recommend **against** adding secret keys to public repositories.
+> Their analysis results are publicly accessible, and your secret keys might get exposed.
 
-## Downloading the SSH public key
+## Add SSH public key to GitHub
 
 ![Download SSH public key](../assets/ssh-key-download-key.png)
 
-After generating, you can download the SSH public key used in analysis sessions from this page. The key is able to be added as [Deploy Keys](https://docs.github.com/en/free-pro-team@latest/developers/overview/managing-deploy-keys#deploy-keys) in GitHub.
+After generating a key pair, click **Download Public Key**. You can download the SSH public key.
 
-> The SSH public key is supposed to be configured in another repository.
->
-> For example, think about the case your repository _my-app_ depends on another private repository _my-lib_, which is hosted on GitHub.
-> You should configure following the steps:
->
-> 1. Access the repository settings page of _my-app_ on Sider.
-> 2. Click **"Generate Key"**.
-> 3. Click **"Download Public Key"**.
-> 4. Access the repository settings page of _my-lib_ on GitHub.
-> 5. Click **"Deploy keys"**.
-> 6. Click **"Add deploy key"**.
-> 7. Copy the downloaded public key and paste it in **"Key"** input form.
-> 8. Click **"Add key"**.
+Next, you need to add the downloaded public key to GitHub.
+You can add it via the following 2 ways:
 
-## Using SSH
+- as a [deploy key](#deploy-key)
+- as an [SSH key of a machine user](#ssh-key-of-machine-user)
 
-Currently, only a few analysis tools use an SSH configuration.
+### Deploy key
 
-- All Ruby analyzers (Bundler)
-- [ESLint](../tools/javascript/eslint.md) (npm)
-- [TSLint](../tools/javascript/tslint.md) (npm)
-- [CoffeeLint](../tools/javascript/coffeelint.md) (npm)
-- [stylelint](../tools/css/stylelint.md) (npm)
+If you have just one private dependency, using a deploy key is simple.
 
-Other tools do not use SSH, so adding an SSH key for such tools are not needed.
+Suppose that you have the following private npm package and private repository hosting it:
+
+- Package name: `awesome`
+- Repository URL: `https://github.com/foo-company/awesome`
+
+Your `package.json` should look like this:
+
+```json
+{
+  "dependencies": {
+    "awesome": "git+ssh://git@github.com:foo-company/awesome.git#v1.2.3"
+  }
+}
+```
+
+To install this package during an analysis session, you need to add the downloaded public key as a deploy key to the `foo-company/awesome` repository on GitHub.
+The steps are as follows:
+
+1. Visit `https://github.com/foo-company/awesome`
+2. Click **Settings**
+3. Click **Deploy keys**
+4. Click **Add deploy key**
+5. Enter the public key and save it
+
+For details, check out the [GitHub documentation](https://docs.github.com/en/free-pro-team@latest/developers/overview/managing-deploy-keys#deploy-keys).
+
+When you add the deploy key and start a new analysis, installing the private package should succeed.
+
+### SSH key of machine user
+
+If you have multiple private dependencies, adding a deploy key does not work.
+Because we cannot add the same deploy to multiple repositories on GitHub.
+
+In such a case, you need to prepare a [machine user](https://docs.github.com/en/free-pro-team@latest/developers/overview/managing-deploy-keys#machine-users) account
+and attach the public key to the account.
+Note that the machine user must have _read_ access to your private repositories.
+
+Suppose that you have a machine user account named _foobot_ and the following `package.json`:
+
+```json
+{
+  "dependencies": {
+    "awesome": "git+ssh://git@github.com:foo-company/awesome.git#v1.2.3",
+    "marvelous": "git+ssh://git@github.com:foo-company/marvelous.git#v0.9.0"
+  }
+}
+```
+
+To install these packages, _foobot_ need to have access to the `foo-company/awesome` and `foo-company/marvelous` repositories.
+Attaching the public key as an SSH key to _foobot_ can realize this.
+The steps are as follows:
+
+1. Login to GitHub as the machine user
+2. Visit **Settings** of the machine user
+3. Click **SSH and GPG keys**
+4. Click **New SSH key**
+5. Enter the public key and save it
+6. Give the machine user access to the private repositories (_read_ access at least)
+
+For details, check out the following documentation on GitHub:
+
+- About [adding a new SSH key](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account)
+- About [managing access to a repository](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/managing-teams-and-people-with-access-to-your-repository)
+
+## Supported package managers
+
+We support the following package managers that can install packages from Git repositories:
+
+- [Bundler](https://bundler.io) (Ruby)
+- [npm](https://www.npmjs.com) (JavaScript)
+
+If you want to install private dependencies via Bundler, note that you need to configure your [`sider.yml`](../getting-started/custom-configuration.md).
+For example:
+
+```yaml
+linter:
+  rubocop:
+    gems:
+      - name: rubocop-foo-company
+        git:
+          repo: git@github.com:foo-company/rubocop-foo-company.git
+          tag: v1.2.3
+```
+
+See the [`gems` option](../getting-started/custom-configuration.md#install-gems-from-git-repository) for details.

--- a/docs/advanced-settings/private-dependencies.md
+++ b/docs/advanced-settings/private-dependencies.md
@@ -74,7 +74,7 @@ When you add the deploy key and start a new analysis, installing the private pac
 ### SSH key of machine user
 
 If you have multiple private dependencies, adding a deploy key does not work
-because we cannot add the same deploy to multiple repositories on GitHub.
+because we cannot add the same deploy key to multiple repositories on GitHub.
 
 In such a case, you need to prepare a [machine user](https://docs.github.com/en/free-pro-team@latest/developers/overview/managing-deploy-keys#machine-users) account
 and attach the public key to the account.

--- a/docs/advanced-settings/private-dependencies.md
+++ b/docs/advanced-settings/private-dependencies.md
@@ -16,13 +16,13 @@ Let's check the following steps out.
 
 ## Generate SSH key pair
 
-First of all, you need to generate an SSH key pair on your repository settings on Sider.
+First, you need to generate an SSH key pair on your repository settings on Sider.
 
 Visit **Settings** on your repository, and then click **Keys**.
 
 ![Generate SSH private key](../assets/ssh-key-generate-key.png)
 
-When you click **Generate Key**, Sider automatically generates a 4096-bit RSA key pair used for the private dependencies resolution.
+When you click **Generate Key**, Sider automatically generates a 4096-bit RSA key pair used for the private dependency resolution.
 
 > NOTE: We strongly recommend **against** adding secret keys to public repositories.
 > Their analysis results are publicly accessible, and your secret keys might get exposed.
@@ -73,8 +73,8 @@ When you add the deploy key and start a new analysis, installing the private pac
 
 ### SSH key of machine user
 
-If you have multiple private dependencies, adding a deploy key does not work.
-Because we cannot add the same deploy to multiple repositories on GitHub.
+If you have multiple private dependencies, adding a deploy key does not work
+because we cannot add the same deploy to multiple repositories on GitHub.
 
 In such a case, you need to prepare a [machine user](https://docs.github.com/en/free-pro-team@latest/developers/overview/managing-deploy-keys#machine-users) account
 and attach the public key to the account.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -83,3 +83,8 @@ To solve the problem, we recommend you to try the following:
 
 The maximum number of changed files in a pull request is **3,000** in Sider.
 An analysis never starts if your changed files exceed the limit.
+
+## Installing dependencies fails
+
+If you are using private dependencies via a package manager (e.g. npm), you need extra steps.
+See ["Private Dependencies"](./advanced-settings/private-dependencies.md) for more details.


### PR DESCRIPTION
Summary:

- Add a section about a machine user
- Clarify the existing descriptions
- Also add a section about private dependencies to the "Troubleshooting" page

See also <https://docs.github.com/en/free-pro-team@latest/developers/overview/managing-deploy-keys>