### PR TITLE
Increase the recommended storage size on System Overview

### DIFF
--- a/docs/enterprise/releases/202012.md
+++ b/docs/enterprise/releases/202012.md
@@ -9,6 +9,12 @@ hide_title: true
 
 ## release-202012.0
 
+**Notes**:
+
+This release includes the new feature, [Analyzing branches](../../news/2020.md#analyzing-branches).
+It might increase the number of analyses in your environment, so we updated [Storage](../system-overview.md#storage) size in System Overview.
+However, the described size is not exactly calculated, so please monitor your resources carefully.
+
 **Features**:
 
 This release includes the following updates:

--- a/docs/enterprise/releases/202012.md
+++ b/docs/enterprise/releases/202012.md
@@ -12,7 +12,7 @@ hide_title: true
 **Notes**:
 
 This release includes the new feature, [Analyzing branches](../../news/2020.md#analyzing-branches).
-It might increase the number of analyses in your environment, so we updated [Storage](../system-overview.md#storage) size in System Overview.
+It might increase the number of analysis in your environment, so we updated [Storage](../system-overview.md#storage) size in System Overview.
 However, the described size is not exactly calculated, so please monitor your resources carefully.
 
 **Features**:

--- a/docs/enterprise/releases/202012.md
+++ b/docs/enterprise/releases/202012.md
@@ -12,7 +12,7 @@ hide_title: true
 **Notes**:
 
 This release includes the new feature, [Analyzing branches](../../news/2020.md#analyzing-branches).
-It might increase the number of analysis in your environment, so we updated [Storage](../system-overview.md#storage) size in System Overview.
+It might increase the number of analysis in your environment, so we updated [Storage](../system-overview.md#storage) size on System Overview.
 However, the described size is not exactly calculated, so please monitor your resources carefully.
 
 **Features**:

--- a/docs/enterprise/system-overview.md
+++ b/docs/enterprise/system-overview.md
@@ -48,7 +48,7 @@ Runners, on the other hand, are the collection of "runner" and perform analyses 
 
 The necessary storage space largely depends on the number of analyses. If your organization has many developers, and they actively change their source code, the required storage space could be huge.
 
-Sider Enterprise mainly consumes the storage space via Docker, MySQL, and MinIO, so you may have to care about the disk space for each service. It is assumed that each service should have 100 GiB storage size on its own at least, but this is a too rough estimate that we could recommend what is the best storage size.
+Sider Enterprise mainly consumes the storage space via Docker, MySQL, and MinIO, so you may have to care about the disk space for each service. It is assumed that each service should have 500 GiB storage size on its own at least, but this is a too rough estimate that we could recommend what is the best storage size.
 
 #### CPU
 


### PR DESCRIPTION
With [Analyzing branches](https://help.sider.review//news/2020#analyzing-branches), Sider Enterprise might require more storage size, so I updated the least storage size from `100` to `500`.

Note this number is not what is exactly calculated, but it's good to prepare more storage size for Sider Enterprise.