### PR TITLE
Add `sourceType` and `env` to ESLint config

### DIFF
--- a/website/.eslintrc.yml
+++ b/website/.eslintrc.yml
@@ -4,3 +4,4 @@ extends:
 
 parserOptions:
   ecmaVersion: 6
+  sourceType: "module"

--- a/website/.eslintrc.yml
+++ b/website/.eslintrc.yml
@@ -8,3 +8,4 @@ parserOptions:
 
 env:
   es6: true
+  node: true

--- a/website/.eslintrc.yml
+++ b/website/.eslintrc.yml
@@ -9,3 +9,7 @@ parserOptions:
 env:
   es6: true
   node: true
+
+rules:
+  # NOTE: Docusaurus components do not have prop types.
+  react/prop-types: "off"

--- a/website/.eslintrc.yml
+++ b/website/.eslintrc.yml
@@ -5,3 +5,6 @@ extends:
 parserOptions:
   ecmaVersion: 6
   sourceType: "module"
+
+env:
+  es6: true


### PR DESCRIPTION
Follow-up of #544

See also <https://eslint.org/docs/user-guide/configuring#specifying-parser-options>