### PR TITLE
Remove language version and runtime from each tool page

### DIFF
--- a/docs/tools/cplusplus/clang-tidy.md
+++ b/docs/tools/cplusplus/clang-tidy.md
@@ -9,9 +9,9 @@ hide_title: true
 
 > This is **BETA**. The behavior of this tool might change.
 
-| Supported Version | Language | Website                                  |
-| ----------------- | -------- | ---------------------------------------- |
-| 10.0.1            | C/C++    | https://clang.llvm.org/extra/clang-tidy/ |
+| Supported Version | Language | Website                                 |
+| ----------------- | -------- | --------------------------------------- |
+| 10.0.1            | C/C++    | https://clang.llvm.org/extra/clang-tidy |
 
 **Clang-Tidy** is a [Clang](https://clang.llvm.org/)-based C++ "linter" tool. It diagnoses typical programming errors, like style violations, interface misuse, or bugs that can be deduced via static analysis.
 

--- a/docs/tools/css/stylelint.md
+++ b/docs/tools/css/stylelint.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # stylelint
 
-| Supported Version        | Language                    | Runtime         | Website              |
-| ------------------------ | --------------------------- | --------------- | -------------------- |
-| 8.3.0+ (default: 13.8.0) | CSS and flavors (e.g. Sass) | Node.js 12.20.0 | https://stylelint.io |
+| Supported Version        | Language                    | Website              |
+| ------------------------ | --------------------------- | -------------------- |
+| 8.3.0+ (default: 13.8.0) | CSS and flavors (e.g. Sass) | https://stylelint.io |
 
 **stylelint** is a pluggable linter to help you avoid errors and enforce conventions for CSS and CSS-like languages.
 It provides many core rules and third-party rules by the community.

--- a/docs/tools/go/golangci-lint.md
+++ b/docs/tools/go/golangci-lint.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # GolangCI-Lint
 
-| Supported Version | Language  | Website                   |
-| ----------------- | --------- | ------------------------- |
-| 1.33.0            | Go 1.15.6 | https://golangci-lint.run |
+| Supported Version | Language | Website                   |
+| ----------------- | -------- | ------------------------- |
+| 1.33.0            | Go       | https://golangci-lint.run |
 
 **GolangCI-Lint** is a linter to aggregate multiple linters and a successor to [Go Meta Linter](gometalinter.md) which is deprecated.
 

--- a/docs/tools/go/golint.md
+++ b/docs/tools/go/golint.md
@@ -9,9 +9,9 @@ hide_title: true
 
 > **DEPRECATED**: Sider dropped the support of Golint on **May 31, 2020**. We recommend [GolangCI-Lint](golangci-lint.md) instead.
 
-| Language  | Website                        |
-| --------- | ------------------------------ |
-| Go 1.14.3 | https://github.com/golang/lint |
+| Language | Website                        |
+| -------- | ------------------------------ |
+| Go       | https://github.com/golang/lint |
 
 ## Getting Started
 

--- a/docs/tools/go/gometalinter.md
+++ b/docs/tools/go/gometalinter.md
@@ -9,9 +9,9 @@ hide_title: true
 
 > **DEPRECATED**: Sider dropped the support of Go Meta Linter on **May 31, 2020**. We recommend [GolangCI-Lint](golangci-lint.md) instead.
 
-| Supported Version | Language  | Website                                    |
-| ----------------- | --------- | ------------------------------------------ |
-| 2.0.11            | Go 1.14.3 | https://github.com/alecthomas/gometalinter |
+| Supported Version | Language | Website                                    |
+| ----------------- | -------- | ------------------------------------------ |
+| 2.0.11            | Go       | https://github.com/alecthomas/gometalinter |
 
 For more details, see the [readme](https://github.com/alecthomas/gometalinter#readme).
 

--- a/docs/tools/go/govet.md
+++ b/docs/tools/go/govet.md
@@ -9,9 +9,9 @@ hide_title: true
 
 > **DEPRECATED**: Sider dropped the support of go vet on **May 31, 2020**. We recommend [GolangCI-Lint](golangci-lint.md) instead.
 
-| Language  | Website                    |
-| --------- | -------------------------- |
-| Go 1.14.3 | https://golang.org/cmd/vet |
+| Language | Website                    |
+| -------- | -------------------------- |
+| Go       | https://golang.org/cmd/vet |
 
 ## Getting Started
 

--- a/docs/tools/java/checkstyle.md
+++ b/docs/tools/java/checkstyle.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # Checkstyle
 
-| Supported Version | Language    | Website                |
-| ----------------- | ----------- | ---------------------- |
-| 8.38              | Java 15.0.1 | https://checkstyle.org |
+| Supported Version | Language | Website                |
+| ----------------- | -------- | ---------------------- |
+| 8.38              | Java     | https://checkstyle.org |
 
 **Checkstyle** is a style checker for Java code and aims to enforce a coding standard.
 

--- a/docs/tools/java/javasee.md
+++ b/docs/tools/java/javasee.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # JavaSee
 
-| Supported Version | Language    | Website                          |
-| ----------------- | ----------- | -------------------------------- |
-| 0.2.0             | Java 15.0.1 | https://github.com/sider/JavaSee |
+| Supported Version | Language | Website                          |
+| ----------------- | -------- | -------------------------------- |
+| 0.2.0             | Java     | https://github.com/sider/JavaSee |
 
 **JavaSee** is a customizable linter for Java code. It has no rules and you can define your own rules in your YAML file.
 

--- a/docs/tools/java/pmd.md
+++ b/docs/tools/java/pmd.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # PMD
 
-| Supported Version | Language    | Website               |
-| ----------------- | ----------- | --------------------- |
-| 6.30.0            | Java 15.0.1 | https://pmd.github.io |
+| Supported Version | Language | Website               |
+| ----------------- | -------- | --------------------- |
+| 6.30.0            | Java     | https://pmd.github.io |
 
 **PMD** is a static analysis tool to detect issues about code style, security, performance, etc.
 It supports multiple programming languages but Sider supports only Java.

--- a/docs/tools/javascript/coffeelint.md
+++ b/docs/tools/javascript/coffeelint.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # CoffeeLint
 
-| Supported Version        | Language     | Runtime         | Website                      |
-| ------------------------ | ------------ | --------------- | ---------------------------- |
-| 1.16.0+ (default: 4.1.2) | CoffeeScript | Node.js 12.20.0 | https://coffeelint.github.io |
+| Supported Version        | Language     | Website                                 |
+| ------------------------ | ------------ | --------------------------------------- |
+| 1.16.0+ (default: 4.1.2) | CoffeeScript | https://coffeelint.github.io |
 
 **CoffeeLint** is a style checker that helps keep CoffeeScript code clean and consistent.
 

--- a/docs/tools/javascript/coffeelint.md
+++ b/docs/tools/javascript/coffeelint.md
@@ -7,8 +7,8 @@ hide_title: true
 
 # CoffeeLint
 
-| Supported Version        | Language     | Website                                 |
-| ------------------------ | ------------ | --------------------------------------- |
+| Supported Version        | Language     | Website                      |
+| ------------------------ | ------------ | ---------------------------- |
 | 1.16.0+ (default: 4.1.2) | CoffeeScript | https://coffeelint.github.io |
 
 **CoffeeLint** is a style checker that helps keep CoffeeScript code clean and consistent.

--- a/docs/tools/javascript/eslint.md
+++ b/docs/tools/javascript/eslint.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # ESLint
 
-| Supported Version        | Language   | Runtime         | Website            |
-| ------------------------ | ---------- | --------------- | ------------------ |
-| 5.0.0+ (default: 7.15.0) | JavaScript | Node.js 12.20.0 | https://eslint.org |
+| Supported Version        | Language   | Website            |
+| ------------------------ | ---------- | ------------------ |
+| 5.0.0+ (default: 7.15.0) | JavaScript | https://eslint.org |
 
 **ESLint** is a static analysis tool for JavaScript and its flavors (e.g. TypeScript, JSX, Vue).
 It can find problems, style violations, or security issues, etc. in your code, and have so many plugins.

--- a/docs/tools/javascript/jshint.md
+++ b/docs/tools/javascript/jshint.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # JSHint
 
-| Supported Version | Language   | Runtime         | Website            |
-| ----------------- | ---------- | --------------- | ------------------ |
-| 2.12.0            | JavaScript | Node.js 12.20.0 | https://jshint.com |
+| Supported Version | Language   | Website            |
+| ----------------- | ---------- | ------------------ |
+| 2.12.0            | JavaScript | https://jshint.com |
 
 **JSHint** is a static analysis tool to detect errors and potential problems in JavaScript code.
 

--- a/docs/tools/javascript/tslint.md
+++ b/docs/tools/javascript/tslint.md
@@ -10,9 +10,9 @@ hide_title: true
 > **DEPRECATED**: TSLint has been deprecated and it recommends migrating to [TypeScript ESLint](https://github.com/typescript-eslint/typescript-eslint).
 > See the [discussion](https://github.com/palantir/tslint/issues/4534) for more details.
 
-| Supported Version       | Language   | Runtime         | Website                           |
-| ----------------------- | ---------- | --------------- | --------------------------------- |
-| 5.0.0+ (default: 6.1.3) | TypeScript | Node.js 12.20.0 | https://palantir.github.io/tslint |
+| Supported Version       | Language   | Website                           |
+| ----------------------- | ---------- | --------------------------------- |
+| 5.0.0+ (default: 6.1.3) | TypeScript | https://palantir.github.io/tslint |
 
 **TSLint** is an extensible static analysis tool for TypeScript.
 It checks your code for readability, maintainability, and functionality errors.

--- a/docs/tools/javascript/tyscan.md
+++ b/docs/tools/javascript/tyscan.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # TyScan
 
-| Supported Version       | Language   | Runtime         | Website                         |
-| ----------------------- | ---------- | --------------- | ------------------------------- |
-| 0.2.1+ (default: 0.3.2) | TypeScript | Node.js 12.20.0 | https://github.com/sider/tyscan |
+| Supported Version       | Language   | Website                         |
+| ----------------------- | ---------- | ------------------------------- |
+| 0.2.1+ (default: 0.3.2) | TypeScript | https://github.com/sider/tyscan |
 
 **TyScan** is a static analysis tool for TypeScript to easily make your custom rules via your YAML file.
 

--- a/docs/tools/kotlin/detekt.md
+++ b/docs/tools/kotlin/detekt.md
@@ -9,9 +9,9 @@ hide_title: true
 
 > This is **BETA**. The behavior of this tool might change.
 
-| Supported Version | Language             | Website                         |
-| ----------------- | -------------------- | ------------------------------- |
-| 1.14.2            | Kotlin (Java 15.0.1) | https://detekt.github.io/detekt |
+| Supported Version | Language | Website                         |
+| ----------------- | -------- | ------------------------------- |
+| 1.14.2            | Kotlin   | https://detekt.github.io/detekt |
 
 **detekt** is a linter which code smell analysis for your [Kotlin](https://kotlinlang.org) projects.
 

--- a/docs/tools/kotlin/ktlint.md
+++ b/docs/tools/kotlin/ktlint.md
@@ -9,9 +9,9 @@ hide_title: true
 
 > This is **BETA**. The behavior of this tool might change.
 
-| Supported Version | Language             | Website                  |
-| ----------------- | -------------------- | ------------------------ |
-| 0.39.0 ¹          | Kotlin (Java 15.0.1) | https://ktlint.github.io |
+| Supported Version | Language | Website                  |
+| ----------------- | -------- | ------------------------ |
+| 0.39.0 ¹          | Kotlin   | https://ktlint.github.io |
 
 **ktlint** is a linter with built-in formatter for [Kotlin](https://kotlinlang.org) programming language.
 

--- a/docs/tools/markdown/remark-lint.md
+++ b/docs/tools/markdown/remark-lint.md
@@ -9,9 +9,9 @@ hide_title: true
 
 > This is **BETA**. The behavior of this tool might change.
 
-| Supported Version         | Language | Runtime         | Website                                 |
-| ------------------------- | -------- | --------------- | --------------------------------------- |
-| 7.0.0+ (default: 9.0.0) ¹ | Markdown | Node.js 12.20.0 | https://github.com/remarkjs/remark-lint |
+| Supported Version         | Language | Website                                 |
+| ------------------------- | -------- | --------------------------------------- |
+| 7.0.0+ (default: 9.0.0) ¹ | Markdown | https://github.com/remarkjs/remark-lint |
 
 **remark-lint** is a pluggable linter for Markdown. It includes many rules to enforce consistency and detect possible mistakes.
 

--- a/docs/tools/others/goodcheck.md
+++ b/docs/tools/others/goodcheck.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # Goodcheck
 
-| Supported Version       | Language        | Website                            |
-| ----------------------- | --------------- | ---------------------------------- |
-| 1.0.0+ (default: 2.7.0) | Others (Regexp) | https://sider.github.io/goodcheck/ |
+| Supported Version       | Language     | Website                           |
+| ----------------------- | ------------ | --------------------------------- |
+| 1.0.0+ (default: 2.7.0) | Various text | https://sider.github.io/goodcheck |
 
 **Goodcheck** is a regex-based customizable linter, which has no rules by default.
 Users can add and manage project-specific rules to their YAML files.

--- a/docs/tools/others/languagetool.md
+++ b/docs/tools/others/languagetool.md
@@ -9,9 +9,9 @@ hide_title: true
 
 > This is **BETA**. The behavior of this tool might change.
 
-| Supported Version | Language    | Website                  |
-| ----------------- | ----------- | ------------------------ |
-| 5.1               | Java 15.0.1 | https://languagetool.org |
+| Supported Version | Language          | Website                  |
+| ----------------- | ----------------- | ------------------------ |
+| 5.1               | Natural languages | https://languagetool.org |
 
 **LanguageTool** is a proofreading tool for [English, French, German, and other languages](https://languagetool.org/languages).
 It finds many mistakes like grammar errors, misspells, and so on.

--- a/docs/tools/others/misspell.md
+++ b/docs/tools/others/misspell.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # Misspell
 
-| Supported Version | Language                | Website                             |
-| ----------------- | ----------------------- | ----------------------------------- |
-| 0.3.4             | Others (Spell checking) | https://github.com/client9/misspell |
+| Supported Version | Language          | Website                             |
+| ----------------- | ----------------- | ----------------------------------- |
+| 0.3.4             | Natural languages | https://github.com/client9/misspell |
 
 **Misspell** is a spell checker to correct commonly misspelled English.
 

--- a/docs/tools/others/pmd-cpd.md
+++ b/docs/tools/others/pmd-cpd.md
@@ -9,9 +9,9 @@ hide_title: true
 
 > This is **BETA**. The behavior of this tool might change.
 
-| Supported Version | Language    | Website               |
-| ----------------- | ----------- | --------------------- |
-| 6.30.0            | (see below) | https://pmd.github.io |
+| Supported Version | Language              | Website               |
+| ----------------- | --------------------- | --------------------- |
+| 6.30.0            | Programming languages | https://pmd.github.io |
 
 **PMD CPD** is the copy-paste detector shipped with PMD. CPD works with Java, JSP, C/C++, C#, Go, Kotlin, Ruby, Swift and [many more languages](https://pmd.github.io/pmd/pmd_userdocs_cpd.html#supported-languages).
 

--- a/docs/tools/php/code-sniffer.md
+++ b/docs/tools/php/code-sniffer.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # PHP_CodeSniffer
 
-| Supported Version | Language   | Website                                      |
-| ----------------- | ---------- | -------------------------------------------- |
-| 3.5.8             | PHP 7.4.12 | https://pear.php.net/package/PHP_CodeSniffer |
+| Supported Version | Language | Website                                      |
+| ----------------- | -------- | -------------------------------------------- |
+| 3.5.8             | PHP      | https://pear.php.net/package/PHP_CodeSniffer |
 
 **PHP_CodeSniffer** is a style checker to enforce a defined set of PHP coding standards.
 

--- a/docs/tools/php/phinder.md
+++ b/docs/tools/php/phinder.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # Phinder
 
-| Supported Version | Language   | Website                          |
-| ----------------- | ---------- | -------------------------------- |
-| 0.9.2             | PHP 7.4.12 | https://github.com/sider/phinder |
+| Supported Version | Language | Website                          |
+| ----------------- | -------- | -------------------------------- |
+| 0.9.2             | PHP      | https://github.com/sider/phinder |
 
 **Phinder** is a static analysis tool that aims to make your custom rules via your YAML file.
 

--- a/docs/tools/php/phpmd.md
+++ b/docs/tools/php/phpmd.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # PHPMD
 
-| Supported Version | Language   | Website           |
-| ----------------- | ---------- | ----------------- |
-| 2.9.1             | PHP 7.4.12 | https://phpmd.org |
+| Supported Version | Language | Website           |
+| ----------------- | -------- | ----------------- |
+| 2.9.1             | PHP      | https://phpmd.org |
 
 **PHPMD** is a static analysis tool focused on detecting code smells and possible errors in your PHP code.
 

--- a/docs/tools/python/flake8.md
+++ b/docs/tools/python/flake8.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # Flake8
 
-| Supported Version | Language     | Website                         |
-| ----------------- | ------------ | ------------------------------- |
-| 3.8.4             | Python 3.9.1 | https://gitlab.com/pycqa/flake8 |
+| Supported Version | Language | Website                         |
+| ----------------- | -------- | ------------------------------- |
+| 3.8.4             | Python   | https://gitlab.com/pycqa/flake8 |
 
 **Flake8** is a linter to check the style and quality of Python code.
 

--- a/docs/tools/python/pylint.md
+++ b/docs/tools/python/pylint.md
@@ -9,9 +9,9 @@ hide_title: true
 
 > This is **BETA**. The behavior of this tool might change.
 
-| Supported Version | Language     | Website                             |
-| ----------------- | ------------ | ----------------------------------- |
-| 2.6.0             | Python 3.9.1 | https://pylint.pycqa.org/en/stable/ |
+| Supported Version | Language | Website                            |
+| ----------------- | -------- | ---------------------------------- |
+| 2.6.0             | Python   | https://pylint.pycqa.org/en/stable |
 
 **Pylint** is a Python static code analysis tool which looks for programming errors, helps to enforce a coding standard, sniffs for code smells and offers simple refactoring suggestions.
 

--- a/docs/tools/ruby/brakeman.md
+++ b/docs/tools/ruby/brakeman.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # Brakeman
 
-| Supported Version        | Language   | Website                     |
-| ------------------------ | ---------- | --------------------------- |
-| 4.0.0+ (default: 4.10.0) | Ruby 2.7.2 | https://brakemanscanner.org |
+| Supported Version        | Language | Website                     |
+| ------------------------ | -------- | --------------------------- |
+| 4.0.0+ (default: 4.10.0) | Ruby     | https://brakemanscanner.org |
 
 **Brakeman** is a static analysis tool to detect security issues in Ruby on Rails applications.
 

--- a/docs/tools/ruby/haml-lint.md
+++ b/docs/tools/ruby/haml-lint.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # HAML-Lint
 
-| Version                   | Language          | Website                          |
-| ------------------------- | ----------------- | -------------------------------- |
-| 0.26.0+ (default: 0.36.0) | HAML (Ruby 2.7.2) | https://github.com/sds/haml-lint |
+| Version                   | Language    | Website                          |
+| ------------------------- | ----------- | -------------------------------- |
+| 0.26.0+ (default: 0.36.0) | HAML (Ruby) | https://github.com/sds/haml-lint |
 
 **HAML-Lint** is a static analysis tool to help keep your [HAML](https://github.com/haml/haml) files clean and readable.
 In addition to HAML-specific style and lint checks, it can check them by integrated RuboCop rules.

--- a/docs/tools/ruby/querly.md
+++ b/docs/tools/ruby/querly.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # Querly
 
-| Supported Version       | Language   | Website                           |
-| ----------------------- | ---------- | --------------------------------- |
-| 0.5.0+ (default: 1.1.0) | Ruby 2.7.2 | https://github.com/soutaro/querly |
+| Supported Version       | Language | Website                           |
+| ----------------------- | -------- | --------------------------------- |
+| 0.5.0+ (default: 1.1.0) | Ruby     | https://github.com/soutaro/querly |
 
 **Querly** is a customizable and pattern-based analysis tool for Ruby.
 You can easily write your own rule for your project via the YAML configuration file.

--- a/docs/tools/ruby/rails-best-practices.md
+++ b/docs/tools/ruby/rails-best-practices.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # Rails Best Practices
 
-| Supported Version         | Language   | Website                         |
-| ------------------------- | ---------- | ------------------------------- |
-| 1.19.1+ (default: 1.20.0) | Ruby 2.7.2 | https://rails-bestpractices.com |
+| Supported Version         | Language | Website                         |
+| ------------------------- | -------- | ------------------------------- |
+| 1.19.1+ (default: 1.20.0) | Ruby     | https://rails-bestpractices.com |
 
 **Rails Best Practices** (abbr. RBP) is a code metric tool to check the quality of Rails code.
 

--- a/docs/tools/ruby/reek.md
+++ b/docs/tools/ruby/reek.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # Reek
 
-| Supported Version       | Language   | Website                           |
-| ----------------------- | ---------- | --------------------------------- |
-| 4.4.0+ (default: 6.0.2) | Ruby 2.7.2 | https://github.com/troessner/reek |
+| Supported Version       | Language | Website                           |
+| ----------------------- | -------- | --------------------------------- |
+| 4.4.0+ (default: 6.0.2) | Ruby     | https://github.com/troessner/reek |
 
 **Reek** is a static analysis tool to detect any "Code Smells" in Ruby classes, modules and methods.
 

--- a/docs/tools/ruby/rubocop.md
+++ b/docs/tools/ruby/rubocop.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # RuboCop
 
-| Supported Version        | Language   | Website             |
-| ------------------------ | ---------- | ------------------- |
-| 0.61.0+ (default: 1.6.1) | Ruby 2.7.2 | https://rubocop.org |
+| Supported Version        | Language | Website             |
+| ------------------------ | -------- | ------------------- |
+| 0.61.0+ (default: 1.6.1) | Ruby     | https://rubocop.org |
 
 **RuboCop** is a pluggable static code analyzer and code formatter for Ruby.
 It has been community-driven developed and has many rules and plugins including third-party's ones.

--- a/docs/tools/swift/swiftlint.md
+++ b/docs/tools/swift/swiftlint.md
@@ -7,9 +7,9 @@ hide_title: true
 
 # SwiftLint
 
-| Supported Version | Language  | Website                            |
-| ----------------- | --------- | ---------------------------------- |
-| 0.41.0            | Swift 5.3 | https://realm.github.io/SwiftLint/ |
+| Supported Version | Language | Website                           |
+| ----------------- | -------- | --------------------------------- |
+| 0.41.0            | Swift    | https://realm.github.io/SwiftLint |
 
 **SwiftLint** is a static analysis tool for Swift. It checks style and conventions, reports code metrics, and so on.
 


### PR DESCRIPTION
We have decided that we no longer need to describe language versions or runtime.