### PR TITLE
[News] 2021-02-12

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,7 @@ This section has documents about analysis tools which Sider supports. We have an
 - [Rails Best Practices](./tools/ruby/rails-best-practices.md)
 - [Brakeman](./tools/ruby/brakeman.md)
 - [HAML-Lint](./tools/ruby/haml-lint.md)
+- [Slim-Lint](./tools/ruby/slim-lint.md)
 
 ### Java
 

--- a/docs/news/2021.md
+++ b/docs/news/2021.md
@@ -13,7 +13,7 @@ This document describes notable changes on Sider in the year 2021.
 
 ## New analysis tool: Slim-Lint
 
-<time class="news-date" datetime="2021-02-10">February 10, 2021</time>
+<time class="news-date" datetime="2021-02-12">February 12, 2021</time>
 
 We are pleased to announce that [**Slim-Lint**](../tools/ruby/slim-lint.md) is newly supported! 🎉
 Slim-Lint is designed to detect issues in [Slim](http://slim-lang.com) files. It is inherently coordinated with [RuboCop](../tools/ruby/rubocop.md), so you can easily integrate them.

--- a/docs/news/2021.md
+++ b/docs/news/2021.md
@@ -11,6 +11,30 @@ This document describes notable changes on Sider in the year 2021.
 
 ---
 
+## New analysis tool: Slim-Lint
+
+<time class="news-date" datetime="2021-02-10">February 10, 2021</time>
+
+We are pleased to announce that [**Slim-Lint**](../tools/ruby/slim-lint.md) is newly supported! 🎉
+This tool is designed to detect issues in the [Slim](http://slim-lang.com) language (a template language for Ruby).
+Especially, the tool can be easily integrated with [RuboCop](../tools/ruby/rubocop.md).
+
+To try this tool, you can simply enable it in your repository settings.
+
+_Note: This tool support is beta yet. Please send us your feedback!_
+
+This release also includes the following tool updates and other changes.
+
+| Tool                                        | Language   | Version             | Ref                                                                  |
+| ------------------------------------------- | ---------- | ------------------- | -------------------------------------------------------------------- |
+| [hadolint](../tools/dockerfile/hadolint.md) | Dockerfile | 1.21.0 → **1.22.1** | [changes](https://github.com/hadolint/hadolint/releases/tag/v1.22.1) |
+
+- [HAML-Lint](../tools/ruby/haml-lint.md): Enable the `parallel` option by default.
+
+If you have any questions, please feel free to contact us. 💬
+
+---
+
 ## Update tools on February 2, 2021
 
 <time class="news-date" datetime="2021-02-02">February 2, 2021</time>

--- a/docs/news/2021.md
+++ b/docs/news/2021.md
@@ -16,8 +16,7 @@ This document describes notable changes on Sider in the year 2021.
 <time class="news-date" datetime="2021-02-10">February 10, 2021</time>
 
 We are pleased to announce that [**Slim-Lint**](../tools/ruby/slim-lint.md) is newly supported! 🎉
-This tool is designed to detect issues in the [Slim](http://slim-lang.com) language (a template language for Ruby).
-Especially, the tool can be easily integrated with [RuboCop](../tools/ruby/rubocop.md).
+Slim-Lint is designed to detect issues in [Slim](http://slim-lang.com) files. It is inherently coordinated with [RuboCop](../tools/ruby/rubocop.md), so you can easily integrate them.
 
 To try this tool, you can simply enable it in your repository settings.
 

--- a/docs/news/2021.md
+++ b/docs/news/2021.md
@@ -24,11 +24,16 @@ _Note: This tool support is beta yet. Please send us your feedback!_
 
 This release also includes the following tool updates and other changes.
 
+Updates:
+
 | Tool                                        | Language   | Version             | Ref                                                                  |
 | ------------------------------------------- | ---------- | ------------------- | -------------------------------------------------------------------- |
 | [hadolint](../tools/dockerfile/hadolint.md) | Dockerfile | 1.21.0 → **1.22.1** | [changes](https://github.com/hadolint/hadolint/releases/tag/v1.22.1) |
 
+Changes:
+
 - [HAML-Lint](../tools/ruby/haml-lint.md): Enable the `parallel` option by default.
+- [HAML-Lint](../tools/ruby/haml-lint.md): Use our default configuration if users' configuration is not specified.
 
 If you have any questions, please feel free to contact us. 💬
 

--- a/docs/tools/dockerfile/hadolint.md
+++ b/docs/tools/dockerfile/hadolint.md
@@ -9,7 +9,7 @@ hide_title: true
 
 | Supported Version | Language   | Website                              |
 | ----------------- | ---------- | ------------------------------------ |
-| 1.21.0            | Dockerfile | https://github.com/hadolint/hadolint |
+| 1.22.1            | Dockerfile | https://github.com/hadolint/hadolint |
 
 **hadolint** is a [Dockerfile](https://docs.docker.com/engine/reference/builder) linter that helps you build best practice Docker images.
 

--- a/docs/tools/ruby/haml-lint.md
+++ b/docs/tools/ruby/haml-lint.md
@@ -57,7 +57,7 @@ You can use several options to fine-tune HAML-Lint to your project.
 | [`exclude_linter`](#exclude_linter)                                                   | `string`, `string[]` | -       |
 | [`config`](#config)                                                                   | `string`             | -       |
 | [`exclude`](#exclude)                                                                 | `string`, `string[]` | -       |
-| [`parallel`](#parallel)                                                               | `boolean`            | `false` |
+| [`parallel`](#parallel)                                                               | `boolean`            | `true`  |
 
 ### `target`
 

--- a/docs/tools/ruby/haml-lint.md
+++ b/docs/tools/ruby/haml-lint.md
@@ -40,7 +40,7 @@ linter:
       - MultilinePipe
     exclude_linter:
       - TagName
-    config: .rubocop_haml.yml
+    config: my-haml-lint.yml
     exclude:
       - app/views/layouts/application.html.haml
     parallel: true
@@ -81,6 +81,9 @@ See also the [`--exclude-linter`](https://github.com/sds/haml-lint#command-line-
 
 This option allows you to specify your config file path for HAML-Lint.
 See also the [`--config`](https://github.com/sds/haml-lint#command-line-flags) option.
+
+You can usually configure HAML-Lint via a file named `.haml-lint.yml` (automatically loaded).
+See the [HAML-Lint documentation](https://github.com/sds/haml-lint#configuration) about details.
 
 ### `exclude`
 

--- a/docs/tools/ruby/haml-lint.md
+++ b/docs/tools/ruby/haml-lint.md
@@ -18,10 +18,14 @@ In addition to HAML-specific style and lint checks, it can check them by integra
 
 To start using HAML-Lint, enable it in your [repository settings](../../getting-started/repository-settings.md).
 
-## Default Configuration for RuboCop
+## Default Configuration
 
-If a `.rubocop.yml` file does not exist in your repository, Sider uses the [default configuration](https://github.com/sider/runners/blob/master/images/haml_lint/default_rubocop.yml)
-including the [MeowCop](https://github.com/sider/meowcop) gem.
+You can configure HAML-Lint via a file named `.haml-lint.yml`.
+But, if this file does not exist in your repository, Sider uses the [default configuration](https://github.com/sider/runners/blob/master/images/haml_lint/sider_recommended_haml_lint.yml) instead.
+
+Similarly, if a `.rubocop.yml` file does not exist, Sider uses the [default configuration for RuboCop](https://github.com/sider/runners/blob/master/images/haml_lint/default_rubocop.yml).
+
+See also the [HAML-Lint configuration](https://github.com/sds/haml-lint#configuration) for details.
 
 ## Configuration
 
@@ -80,10 +84,7 @@ See also the [`--exclude-linter`](https://github.com/sds/haml-lint#command-line-
 ### `config`
 
 This option allows you to specify your config file path for HAML-Lint.
-See also the [`--config`](https://github.com/sds/haml-lint#command-line-flags) option.
-
-You can usually configure HAML-Lint via a file named `.haml-lint.yml` (automatically loaded).
-See the [HAML-Lint documentation](https://github.com/sds/haml-lint#configuration) about details.
+See also the [`--config`](https://github.com/sds/haml-lint#command-line-flags) option and ["Default Configuration"](#default-configuration).
 
 ### `exclude`
 

--- a/docs/tools/ruby/haml-lint.md
+++ b/docs/tools/ruby/haml-lint.md
@@ -11,7 +11,7 @@ hide_title: true
 | ------------------------- | ----------- | -------------------------------- |
 | 0.26.0+ (default: 0.37.0) | HAML (Ruby) | https://github.com/sds/haml-lint |
 
-**HAML-Lint** is a static analysis tool to help keep your [HAML](https://github.com/haml/haml) files clean and readable.
+**HAML-Lint** is a static analysis tool to help keep your [HAML](https://haml.info) files clean and readable.
 In addition to HAML-specific style and lint checks, it can check them by integrated RuboCop rules.
 
 ## Getting Started
@@ -92,5 +92,5 @@ See also the [`--exclude`](https://github.com/sds/haml-lint#command-line-flags) 
 
 ### `parallel`
 
-This option allows you to run linters in parallel.
+This option allows you to run linters in parallel (since [0.36.0](https://github.com/sds/haml-lint/releases/tag/v0.36.0)).
 See also the [`--parallel`](https://github.com/sds/haml-lint#command-line-flags) option.

--- a/docs/tools/ruby/slim-lint.md
+++ b/docs/tools/ruby/slim-lint.md
@@ -5,7 +5,7 @@ sidebar_label: Slim-Lint (beta)
 hide_title: true
 ---
 
-# HAML-Lint
+# Slim-Lint
 
 > This is **BETA**. The behavior of this tool might change.
 

--- a/docs/tools/ruby/slim-lint.md
+++ b/docs/tools/ruby/slim-lint.md
@@ -1,0 +1,60 @@
+---
+id: slim-lint
+title: Slim-Lint
+sidebar_label: Slim-Lint (beta)
+hide_title: true
+---
+
+# HAML-Lint
+
+> This is **BETA**. The behavior of this tool might change.
+
+| Version                   | Language    | Website                          |
+| ------------------------- | ----------- | -------------------------------- |
+| 0.20.2+ (default: 0.20.2) | Slim (Ruby) | https://github.com/sds/slim-lint |
+
+**Slim-Lint** is a static analysis tool to help keep your [Slim](http://slim-lang.com) files clean and readable.
+In addition to Slim-specific style and lint checks, it can check them by integrated RuboCop rules.
+
+## Getting Started
+
+To start using Slim-Lint, enable it in your [repository settings](../../getting-started/repository-settings.md).
+
+## Default Configuration for RuboCop
+
+If a `.rubocop.yml` file does not exist in your repository, Sider uses the [default configuration](https://github.com/sider/runners/blob/master/images/slim_lint/default_rubocop.yml)
+including the [MeowCop](https://github.com/sider/meowcop) gem.
+
+## Configuration
+
+Here is an example configuration via `sider.yml`:
+
+```yaml
+linter:
+  slim_lint:
+    gems:
+      - rubocop
+      - slim
+    target: src
+    config: my-slim-lint.yml
+```
+
+You can use several options to fine-tune HAML-Lint to your project.
+
+| Name                                                                                  | Type                 | Default |
+| ------------------------------------------------------------------------------------- | -------------------- | ------- |
+| [`root_dir`](../../getting-started/custom-configuration.md#linteranalyzer_idroot_dir) | `string`             | -       |
+| [`gems`](../../getting-started/custom-configuration.md#linteranalyzer_idgems)         | `string[]`, `hash[]` | -       |
+| [`target`](#target)                                                                   | `string`, `string[]` | `.`     |
+| [`config`](#config)                                                                   | `string`             | -       |
+
+### `target`
+
+This option allows you to specify files or directories you want to analyze. Glob is also available.
+
+### `config`
+
+This option allows you to specify your config file path for Slim-Lint.
+
+You can usually configure Slim-Lint via a file named `.slim-lint.yml` (automatically loaded).
+See the [Slim-Lint documentation](https://github.com/sds/slim-lint#configuration) about details.

--- a/docs/tools/ruby/slim-lint.md
+++ b/docs/tools/ruby/slim-lint.md
@@ -20,10 +20,14 @@ In addition to Slim-specific style and lint checks, it can check them by integra
 
 To start using Slim-Lint, enable it in your [repository settings](../../getting-started/repository-settings.md).
 
-## Default Configuration for RuboCop
+## Default Configuration
 
-If a `.rubocop.yml` file does not exist in your repository, Sider uses the [default configuration](https://github.com/sider/runners/blob/master/images/slim_lint/default_rubocop.yml)
-including the [MeowCop](https://github.com/sider/meowcop) gem.
+You can configure Slim-Lint via a file named `.slim-lint.yml`.
+But, if this file does not exist in your repository, Sider uses the [default configuration](https://github.com/sider/runners/blob/master/images/slim_lint/sider_recommended_slim_lint.yml) instead.
+
+Similarly, if a `.rubocop.yml` file does not exist, Sider uses the [default configuration for RuboCop](https://github.com/sider/runners/blob/master/images/slim_lint/default_rubocop.yml).
+
+See also the [Slim-Lint configuration](https://github.com/sds/slim-lint#configuration) for details.
 
 ## Configuration
 
@@ -55,6 +59,4 @@ This option allows you to specify files or directories you want to analyze. Glob
 ### `config`
 
 This option allows you to specify your config file path for Slim-Lint.
-
-You can usually configure Slim-Lint via a file named `.slim-lint.yml` (automatically loaded).
-See the [Slim-Lint documentation](https://github.com/sds/slim-lint#configuration) about details.
+See also ["Default Configuration"](#default-configuration).

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -22,7 +22,8 @@
           "tools/ruby/querly",
           "tools/ruby/rails-best-practices",
           "tools/ruby/brakeman",
-          "tools/ruby/haml-lint"
+          "tools/ruby/haml-lint",
+          "tools/ruby/slim-lint"
         ]
       },
       {


### PR DESCRIPTION
The document structure is similar to the HAML-Lint's one:
https://github.com/sider/sider-docs/blob/slim-lint/docs/tools/ruby/haml-lint.md

See also <https://github.com/sider/runners/pull/2014>.

### To-do

- [x] Wait for the next release of Runners.