### PR TITLE
[Cppcheck] Sort options in `sider.yml` example

### DIFF
--- a/docs/tools/cplusplus/cppcheck.md
+++ b/docs/tools/cplusplus/cppcheck.md
@@ -30,13 +30,13 @@ Here is a configuration example via [`sider.yml`](../../getting-started/custom-c
 ```yaml
 linter:
   cppcheck:
+    include-path: "myinclude"
     target: "src"
     ignore: "vendor"
     enable: "all"
     std: "c99"
     project: "your_project.sln"
     language: "c++"
-    include-path: "myinclude"
     addon: "cert"
     bug-hunting: true
     parallel: true


### PR DESCRIPTION
This change makes the order of the options in the `sider.yml` example the same as one in the **options** table.