### PR TITLE
Make more accurate description about removed Go tools

### DIFF
--- a/docs/tools/go/golangci-lint.md
+++ b/docs/tools/go/golangci-lint.md
@@ -27,8 +27,7 @@ See the [default configuration file](https://github.com/sider/runners/blob/maste
 
 ### Migration from Govet and Golint
 
-Sider has deprecated [Govet](./govet.md) and [Golint](./golint.md) and instead recommended GolangCI-Lint.
-If you want to continue using them, all you have to do is enable GolangCI-Lint. They are enabled by default.
+Sider has removed [Govet](govet.md) and [Golint](golint.md). Please use GolangCI-Lint instead. These tools are enabled by default.
 
 If you want to run only Govet or Golint as before, edit your configuration file as follows:
 

--- a/docs/tools/go/golint.md
+++ b/docs/tools/go/golint.md
@@ -1,13 +1,13 @@
 ---
 id: golint
 title: Golint
-sidebar_label: Golint (deprecated)
+sidebar_label: Golint (removed)
 hide_title: true
 ---
 
 # Golint
 
-> **DEPRECATED**: Sider dropped the support of Golint on **May 31, 2020**. We recommend [GolangCI-Lint](golangci-lint.md) instead.
+> **REMOVED**: Sider has removed the support of Golint on **May 31, 2020**. Please use [GolangCI-Lint](golangci-lint.md) instead.
 
 | Language | Website                        |
 | -------- | ------------------------------ |

--- a/docs/tools/go/gometalinter.md
+++ b/docs/tools/go/gometalinter.md
@@ -1,13 +1,13 @@
 ---
 id: gometalinter
 title: Go Meta Linter
-sidebar_label: Go Meta Linter (deprecated)
+sidebar_label: Go Meta Linter (removed)
 hide_title: true
 ---
 
 # Go Meta Linter
 
-> **DEPRECATED**: Sider dropped the support of Go Meta Linter on **May 31, 2020**. We recommend [GolangCI-Lint](golangci-lint.md) instead.
+> **REMOVED**: Sider has removed the support of Go Meta Linter on **May 31, 2020**. Please use [GolangCI-Lint](golangci-lint.md) instead.
 
 | Supported Version | Language | Website                                    |
 | ----------------- | -------- | ------------------------------------------ |

--- a/docs/tools/go/govet.md
+++ b/docs/tools/go/govet.md
@@ -1,13 +1,13 @@
 ---
 id: govet
 title: go vet
-sidebar_label: go vet (deprecated)
+sidebar_label: go vet (removed)
 hide_title: true
 ---
 
 # go vet
 
-> **DEPRECATED**: Sider dropped the support of go vet on **May 31, 2020**. We recommend [GolangCI-Lint](golangci-lint.md) instead.
+> **REMOVED**: Sider has removed the support of go vet on **May 31, 2020**. Please use [GolangCI-Lint](golangci-lint.md) instead.
 
 | Language | Website                    |
 | -------- | -------------------------- |


### PR DESCRIPTION
Govet, Golint, and GoMetaLinter has been removed already, so *deprecated* is inaccurate.