### PR TITLE
[Reek] Add description about `.reek.yml`

### DIFF
--- a/docs/tools/ruby/reek.md
+++ b/docs/tools/ruby/reek.md
@@ -49,7 +49,7 @@ This option allows you to specify files or directories to analyze.
 ### `config`
 
 This option allows you to specify your configuration file.
-If omitted, Reek tries to automatically find a configuration file in your repository.
+If omitted, Reek tries to automatically find a configuration file ([`.reek.yml`](https://github.com/troessner/reek#configuration-file)) in your repository.
 
 ## Default Configuration
 


### PR DESCRIPTION
`.reek.yml` is a default configuration file name of Reek. I think it useful to describe this file name in our documentation.
See <https://github.com/troessner/reek#configuration-file>.