### PR TITLE
Rename RuboCop organization: rubocop-hq -> rubocop

### DIFF
--- a/docs/tools/ruby/rubocop.md
+++ b/docs/tools/ruby/rubocop.md
@@ -65,6 +65,6 @@ If confirming whether a cop is _safe_ or not, see the [cops' document](https://d
 ### `rails`
 
 > **DEPRECATED**: The option is ignored when using the version `0.72.0` or later, and will be removed in the future.
-> Use [`rubocop-rails`](https://github.com/rubocop-hq/rubocop-rails) instead.
+> Use [`rubocop-rails`](https://github.com/rubocop/rubocop-rails) instead.
 
 This option allows you to select whether using Rails cops or not. If omitted, Sider automatically determines it.


### PR DESCRIPTION
See <https://github.com/rubocop/rubocop/discussions/9517> for details.