### PR TITLE
Simplify remark-validate-links configuration

### DIFF
--- a/.remarkrc.yml
+++ b/.remarkrc.yml
@@ -8,4 +8,4 @@ plugins:
   remark-lint-code-block-syntax: true
 
   # NOTE: This is *not* a lint rule and does not have a severity.
-  remark-validate-links: { root: ".", repository: "sider/sider-docs" }
+  remark-validate-links: true


### PR DESCRIPTION
> Typically, you don’t need to configure remark-validate-links, as it detects local Git repositories. 

https://github.com/remarkjs/remark-validate-links/blob/10.0.4/readme.md#configuration