### PR TITLE
[Flake8] Change plugin example

### DIFF
--- a/docs/tools/python/flake8.md
+++ b/docs/tools/python/flake8.md
@@ -35,7 +35,7 @@ linter:
     target: src/
     config: .config/.flake8
     plugins:
-      - flake8-bandit
+      - flake8-bugbear
       - flake8-builtins==1.4.1
       - flake8-docstrings>=1.4.0
       - git+https://github.com/PyCQA/flake8-import-order.git@51e16f33065512afa1a85a20b2c2d3be768f78ea


### PR DESCRIPTION
`flake8-bandit` seems inactive. Instead, this change uses `flake8-bugbear`.

See also:
- https://github.com/PyCQA/flake8-bugbear
- https://github.com/tylerwince/flake8-bandit