### PR TITLE
[Enterprise] Add requirement information (Jan 2021 release)

### DIFF
--- a/docs/enterprise/releases/202101.md
+++ b/docs/enterprise/releases/202101.md
@@ -9,7 +9,7 @@ hide_title: true
 
 ## PLEASE CHECK GitHub Enterprise Server Version
 
-Sider requires GitHub Enterprise Server `2.22` or later from these releases. Please ask the administrator of your GitHub Enterprise Server if you don't know its version.
+Sider Enterprise requires GitHub Enterprise Server `2.22` or later from these releases. Please make sure that your GitHub Enterprise Server is updated to the compatible version.
 
 ## release-202101.1
 

--- a/docs/enterprise/releases/202101.md
+++ b/docs/enterprise/releases/202101.md
@@ -7,6 +7,11 @@ hide_title: true
 
 # Sider Enterprise Release Note in January 2021
 
+
+## PLEASE CHECK GitHub Enterprise Server Version
+
+Sider requires GitHub Enterprise Server `2.22` or later from these releases. Please ask the administrator of your GitHub Enterprise Server if you don't know its version.
+
 ## release-202101.1
 
 **Notes**:

--- a/docs/enterprise/releases/202101.md
+++ b/docs/enterprise/releases/202101.md
@@ -7,7 +7,6 @@ hide_title: true
 
 # Sider Enterprise Release Note in January 2021
 
-
 ## PLEASE CHECK GitHub Enterprise Server Version
 
 Sider requires GitHub Enterprise Server `2.22` or later from these releases. Please ask the administrator of your GitHub Enterprise Server if you don't know its version.


### PR DESCRIPTION
Sider can't work with GitHub Enterprise Server before version `2.22`. Add a caution message to the release notes for Jan 2021 release.