### PR TITLE
Update node version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.11.4
+FROM node
 
 WORKDIR /app/website
 


### PR DESCRIPTION
This change should resolve the following error:

```
error fs-extra@9.1.0: The engine "node" is incompatible with this module. Expected version ">=10".
error Found incompatible module
```