### PR TITLE
[hadolint] Fix inaccurate description about `targer` option

### DIFF
--- a/docs/tools/dockerfile/hadolint.md
+++ b/docs/tools/dockerfile/hadolint.md
@@ -44,7 +44,7 @@ You can use the following options to fine-tune hadolint to your project.
 
 ### `target`
 
-This option allows you to specify files or directories to analyze. If you specify some targets, configure as follows:
+This option allows you to specify files or glob patterns to analyze. If you specify some targets, configure as follows:
 
 ```yaml
 linter:


### PR DESCRIPTION
`hadolint` does not allow directories as arguments:

- https://github.com/sider/runners/blob/c31bbdfe2004869dbea294b9582671a568c4cb4b/lib/runners/processor/hadolint.rb#L45
- https://github.com/sider/runners/blob/c31bbdfe2004869dbea294b9582671a568c4cb4b/lib/runners/processor/hadolint.rb#L68-L79